### PR TITLE
torso length changed, arm and torso position added to calibration, sdh moved

### DIFF
--- a/cob_hardware_config/cob3-3/calibration/calibration.urdf.xacro
+++ b/cob_hardware_config/cob3-3/calibration/calibration.urdf.xacro
@@ -21,30 +21,30 @@
 	<property name="arm_6_ref" value="0" />
 	<property name="arm_7_ref" value="0" />
 
+	<!-- ***************************** -->
 	<!-- camera calibration properties -->
-	<!-- hand eye calibration -->
-	<property name="cam_l_x"     value="-0.05" />
-	<property name="cam_l_y"     value="-0.1" />
-	<property name="cam_l_z"     value="0.05" />
-	<property name="cam_l_roll"  value="0" />
-	<property name="cam_l_pitch" value="0" />
-	<property name="cam_l_yaw"   value="0.05" />
+	<!-- ***************************** -->
+	<!-- left | handeye calibration | relative to head_axis_link -->
+	<property name="cam_l_x" value="-0.035"/>
+	<property name="cam_l_y" value="-0.0065"/>
+	<property name="cam_l_z" value="-0.06"/>
+	<property name="cam_l_roll" value="0.0"/>
+	<property name="cam_l_pitch" value="-1.5708"/>
+	<property name="cam_l_yaw" value="0.0"/>
 
-	<!-- right to left calibration -->
-	<property name="cam_r_x"     value="0.00054365178233795" />
-	<property name="cam_r_y"     value="0.00073586337673354628" />
-	<property name="cam_r_z"     value="-0.0038859562618748719" />
-	<property name="cam_r_roll"  value="0.0034134887305219998" />
-	<property name="cam_r_pitch" value="0.0063635519946461539" />
-	<property name="cam_r_yaw"   value="0.0118074359886706" />
+	<!-- right | stereo baseline calibration | relative to left camera -->
+	<property name="cam_r_x" value="0.12"/>
+	<property name="cam_r_y" value="0.0"/>
+	<property name="cam_r_z" value="0.0"/>
+	<property name="cam_r_roll" value="0.0"/>
+	<property name="cam_r_pitch" value="0.0"/>
+	<property name="cam_r_yaw" value="0.0"/>
 
-	<!-- cam3d to left calibration -->
-	<!--property name="cam3d_x"  value="0.06099859" /-->
-	<property name="cam3d_x"     value="0.01971630" />
-	<property name="cam3d_y"     value="-0.03026699" />
-	<property name="cam3d_z"     value="0.00191677" />
-	<property name="cam3d_roll"  value="-0.00479" />
-	<property name="cam3d_pitch" value="-0.00374" />
-	<property name="cam3d_yaw"   value="0.00063" />
-  
+	<!-- cam3d | handeye calibration | relative to head_axis_link -->
+	<property name="cam3d_x" value="-0.05"/>
+	<property name="cam3d_y" value="-0.04"/>
+	<property name="cam3d_z" value="-0.01"/>
+	<property name="cam3d_roll" value="0.0"/>
+	<property name="cam3d_pitch" value="-1.5708"/>
+	<property name="cam3d_yaw" value="0.0"/>
 </robot>

--- a/cob_hardware_config/cob3-3/calibration/calibration.urdf.xacro
+++ b/cob_hardware_config/cob3-3/calibration/calibration.urdf.xacro
@@ -1,25 +1,36 @@
 <?xml version="1.0"?>
 <robot>
 
-	<!-- torso reference positions -->
-	<property name="torso_lower_neck_tilt_ref" value="-0.2893" />
-	<property name="torso_pan_ref" value="-0.0146" />
-	<property name="torso_upper_neck_tilt_ref" value="0.18198" />
+	<!-- *********************************** -->
+	<!-- kinematic chain reference positions -->
+	<!-- *********************************** -->
+	<!-- torso chain calibration_offest! | relative to reference position (see below)-->
+	<!-- not used right now
+	<property name="torso_lower_neck_tilt_cal_offset" value="0.0"/>
+	<property name="torso_pan_cal_offset" value="0.0"/>
+	<property name="torso_upper_neck_tilt_cal_offset" value="0.0"/>
+	-->
 
-	<!-- tray reference position -->
-	<property name="torso_tray_ref" value="3.14" />
+	<!-- torso reference positions | used as calibration_rising for torso chain -->
+	<!-- ! set these values to make torso straight with (0, 0, 0) joint angles ! -->
+	<property name="torso_lower_neck_tilt_ref" value="-0.24501037"/>
+	<property name="torso_pan_ref" value="-0.0146"/>
+	<property name="torso_upper_neck_tilt_ref" value="+0.14419551"/>
 
-	<!-- head camera axis reference position -->
-	<property name="head_axis_ref" value="-0.1" />
+	<!-- tray reference position | used as calibration_rising for tray chain -->
+	<property name="torso_tray_ref" value="3.14"/>
 
-	<!-- arm reference positions -->
-	<property name="arm_1_ref" value="0" />
-	<property name="arm_2_ref" value="0" />
-	<property name="arm_3_ref" value="0" />
-	<property name="arm_4_ref" value="0" />
-	<property name="arm_5_ref" value="0" />
-	<property name="arm_6_ref" value="0" />
-	<property name="arm_7_ref" value="0" />
+	<!-- head camera axis reference position | used as calibration_rising for head axis chain -->
+	<property name="head_axis_ref" value="-0.1"/>
+
+	<!-- arm reference positions | used as calibration_rising for arm chain-->
+	<property name="arm_1_ref" value="0.0"/>
+	<property name="arm_2_ref" value="0.0"/>
+	<property name="arm_3_ref" value="0.0"/>
+	<property name="arm_4_ref" value="0.0"/>
+	<property name="arm_5_ref" value="0.0"/>
+	<property name="arm_6_ref" value="0.0"/>
+	<property name="arm_7_ref" value="0.0"/>
 
 	<!-- ***************************** -->
 	<!-- camera calibration properties -->

--- a/cob_hardware_config/cob3-3/calibration/calibration.urdf.xacro
+++ b/cob_hardware_config/cob3-3/calibration/calibration.urdf.xacro
@@ -1,5 +1,22 @@
-<?xml version="1.0"?>
-<robot>
+<?xml version="1.0" ?><robot>
+	<!-- ***************** -->
+	<!-- robot calibration -->
+	<!-- ***************** -->
+	<!-- torso mount positions | relative to base_link -->
+	<property name="torso_x" value="0.155"/>
+	<property name="torso_y" value="0.0"/>
+	<property name="torso_z" value="0.892"/>
+	<property name="torso_roll" value="1.5708"/>
+	<property name="torso_pitch" value="0.0"/>
+	<property name="torso_yaw" value="0.0"/>
+
+	<!-- arm mount positions | relative to base_link -->
+	<property name="arm_x" value="-0.015982"/>
+	<property name="arm_y" value="-0.080992"/>
+	<property name="arm_z" value="0.875995"/>
+	<property name="arm_roll" value="0.7854"/>
+	<property name="arm_pitch" value="0.0"/>
+	<property name="arm_yaw" value="-0.2618"/>
 
 	<!-- *********************************** -->
 	<!-- kinematic chain reference positions -->

--- a/cob_hardware_config/cob3-3/calibration/default/calibration.urdf.xacro
+++ b/cob_hardware_config/cob3-3/calibration/default/calibration.urdf.xacro
@@ -1,0 +1,78 @@
+<?xml version="1.0" ?><robot>
+	<!-- ***************** -->
+	<!-- robot calibration -->
+	<!-- ***************** -->
+	<!-- torso mount positions | relative to base_link -->
+	<property name="torso_x" value="0.155"/>
+	<property name="torso_y" value="0.0"/>
+	<property name="torso_z" value="0.892"/>
+	<property name="torso_roll" value="1.5708"/>
+	<property name="torso_pitch" value="0.0"/>
+	<property name="torso_yaw" value="0.0"/>
+
+	<!-- arm mount positions | relative to base_link -->
+	<property name="arm_x" value="-0.015982"/>
+	<property name="arm_y" value="-0.080992"/>
+	<property name="arm_z" value="0.875995"/>
+	<property name="arm_roll" value="0.7854"/>
+	<property name="arm_pitch" value="0.0"/>
+	<property name="arm_yaw" value="-0.2618"/>
+
+	<!-- *********************************** -->
+	<!-- kinematic chain reference positions -->
+	<!-- *********************************** -->
+	<!-- torso chain calibration_offest! | relative to reference position (see below)-->
+	<!-- not used right now
+	<property name="torso_lower_neck_tilt_cal_offset" value="0.0"/>
+	<property name="torso_pan_cal_offset" value="0.0"/>
+	<property name="torso_upper_neck_tilt_cal_offset" value="0.0"/>
+	-->
+
+	<!-- torso reference positions | used as calibration_rising for torso chain -->
+	<!-- ! set these values to make torso straight with (0, 0, 0) joint angles ! -->
+	<property name="torso_lower_neck_tilt_ref" value="-0.24501037"/>
+	<property name="torso_pan_ref" value="-0.0146"/>
+	<property name="torso_upper_neck_tilt_ref" value="+0.14419551"/>
+
+	<!-- tray reference position | used as calibration_rising for tray chain -->
+	<property name="torso_tray_ref" value="3.14"/>
+
+	<!-- head camera axis reference position | used as calibration_rising for head axis chain -->
+	<property name="head_axis_ref" value="-0.1"/>
+
+	<!-- arm reference positions | used as calibration_rising for arm chain-->
+	<property name="arm_1_ref" value="0.0"/>
+	<property name="arm_2_ref" value="0.0"/>
+	<property name="arm_3_ref" value="0.0"/>
+	<property name="arm_4_ref" value="0.0"/>
+	<property name="arm_5_ref" value="0.0"/>
+	<property name="arm_6_ref" value="0.0"/>
+	<property name="arm_7_ref" value="0.0"/>
+
+	<!-- ***************************** -->
+	<!-- camera calibration properties -->
+	<!-- ***************************** -->
+	<!-- left | handeye calibration | relative to head_axis_link -->
+	<property name="cam_l_x" value="-0.035"/>
+	<property name="cam_l_y" value="-0.0065"/>
+	<property name="cam_l_z" value="-0.06"/>
+	<property name="cam_l_roll" value="0.0"/>
+	<property name="cam_l_pitch" value="-1.5708"/>
+	<property name="cam_l_yaw" value="0.0"/>
+
+	<!-- right | stereo baseline calibration | relative to left camera -->
+	<property name="cam_r_x" value="0.12"/>
+	<property name="cam_r_y" value="0.0"/>
+	<property name="cam_r_z" value="0.0"/>
+	<property name="cam_r_roll" value="0.0"/>
+	<property name="cam_r_pitch" value="0.0"/>
+	<property name="cam_r_yaw" value="0.0"/>
+
+	<!-- cam3d | handeye calibration | relative to head_axis_link -->
+	<property name="cam3d_x" value="-0.05"/>
+	<property name="cam3d_y" value="-0.04"/>
+	<property name="cam3d_z" value="-0.01"/>
+	<property name="cam3d_roll" value="0.0"/>
+	<property name="cam3d_pitch" value="-1.5708"/>
+	<property name="cam3d_yaw" value="0.0"/>
+</robot>

--- a/cob_hardware_config/cob3-3/urdf/cob3-3.urdf.xacro
+++ b/cob_hardware_config/cob3-3/urdf/cob3-3.urdf.xacro
@@ -42,7 +42,7 @@
   </xacro:cob_lbr>
   
   <xacro:cob_head_v3 name="head" parent="torso_upper_neck_tilt_link">
-    <origin xyz="0 0.154 0" rpy="0 0 0" />
+    <origin xyz="0 0.173 0" rpy="0 0 0" />
   </xacro:cob_head_v3>
   
   <xacro:schunk_sdh name="sdh" parent="arm_7_link">

--- a/cob_hardware_config/cob3-3/urdf/cob3-3.urdf.xacro
+++ b/cob_hardware_config/cob3-3/urdf/cob3-3.urdf.xacro
@@ -34,11 +34,11 @@
   <xacro:cob_base name="base"/>
 
   <xacro:cob_torso_v1 name="torso" parent="base_link">
-    <origin xyz="0.155 0 0.892" rpy="1.5708 0 0" />
+    <origin xyz="${torso_x} ${torso_y} ${torso_z}" rpy="${torso_roll} ${torso_pitch} ${torso_yaw}" />
   </xacro:cob_torso_v1>
   
   <xacro:cob_lbr name="arm" parent="base_link">
-    <origin xyz="-0.015982 -0.080992 0.875995" rpy="0.7854 0.0 -0.2618" />
+    <origin xyz="${arm_x} ${arm_y} ${arm_z}" rpy="${arm_roll} ${arm_pitch} ${arm_yaw}" />
   </xacro:cob_lbr>
   
   <xacro:cob_head_v3 name="head" parent="torso_upper_neck_tilt_link">

--- a/cob_hardware_config/cob3-3/urdf/cob3-3.urdf.xacro
+++ b/cob_hardware_config/cob3-3/urdf/cob3-3.urdf.xacro
@@ -46,7 +46,7 @@
   </xacro:cob_head_v3>
   
   <xacro:schunk_sdh name="sdh" parent="arm_7_link">
-    <origin xyz="0 0 0.02" rpy="0 0 1.5708" />
+    <origin xyz="0 0 0.032" rpy="0 0 1.5708" />
   </xacro:schunk_sdh>
   
 </robot>


### PR DESCRIPTION
current and default calibration.urdf.xacro provide default calibration: arm, torso and camera positions set to default

depends on pull request 5 in cob_common: https://github.com/ipa320/cob_common/pull/5
