### PR TITLE
cob3-2: New schunk components hardware config files, new calibration and minor config errors fixed

### DIFF
--- a/cob_bringup/robots/cob3-2.xml
+++ b/cob_bringup/robots/cob3-2.xml
@@ -55,6 +55,8 @@
 		<include file="$(find cob_bringup)/components/prosilica_left.launch" />
 		<include file="$(find cob_bringup)/components/prosilica_right.launch" />
 		<include file="$(find cob_sound)/ros/launch/sound.launch" />
+                <include file="$(find cob_bringup)/components/light.launch" />
+
 	</group>
 
 	<machine name="pc1" address="$(arg pc1)" default="true"/>

--- a/cob_hardware_config/cob3-2/calibration/calibration.urdf.xacro
+++ b/cob_hardware_config/cob3-2/calibration/calibration.urdf.xacro
@@ -76,7 +76,9 @@
 	<property name="tray_ref" value="4.1451" />
 
 	<!-- head camera axis reference position | used as calibration_rising for head axis chain -->
-	<property name="head_axis_ref" value="+3.14" />
+	<property name="head_axis_ref" value="0.8" />
+        <!--property name="head_axis_ref" value="0.75" /-->
+
 
 	<!-- arm reference positions | used as calibration_rising for arm chain-->
 	<property name="arm_1_ref" value="-2.8761" />

--- a/cob_hardware_config/cob3-2/config/cameras/parameters_right.yaml
+++ b/cob_hardware_config/cob3-2/config/cameras/parameters_right.yaml
@@ -1,3 +1,4 @@
+ip_address: 192.168.21.102
 auto_exposure:     True
 exposure_auto_max: 100000
 exposure_auto_target: 40
@@ -9,5 +10,7 @@ auto_whitebalance: True
 frame_id: head_color_camera_r_link
 stream_bytes_per_second: 55000000
 auto_adjust_stream_bytes_per_second: False
-trigger_mode: syncin1
+trigger_mode: streaming
+#trigger_mode: syncin1
 packet_size: 9000
+trig_rate: 1

--- a/cob_hardware_config/cob3-2/config/diagnostics_analyzers.yaml
+++ b/cob_hardware_config/cob3-2/config/diagnostics_analyzers.yaml
@@ -93,8 +93,8 @@ analyzers:
         contains: 'head_controller'
       arm:
         type: diagnostic_aggregator/GenericAnalyzer
-        path: LBR
-        contains: 'cob_lbr'
+        path: LWA
+        contains: 'arm_controller'
       base:
         type: diagnostic_aggregator/GenericAnalyzer
         path: Base

--- a/cob_hardware_config/cob3-2/config/lwa.yaml
+++ b/cob_hardware_config/cob3-2/config/lwa.yaml
@@ -2,6 +2,7 @@ can_module: PCAN
 can_device: /dev/pcan2
 can_baudrate: 1000
 modul_ids: [4,5,6,7,8,9,10]
+module_types: [PW,PW,PW,PW,PW,PW,PW]
 joint_names: [arm_1_joint, arm_2_joint, arm_3_joint, arm_4_joint, arm_5_joint, arm_6_joint, arm_7_joint]
 max_accelerations: [0.8,0.8,0.8,0.8,0.8,0.8,0.8]
 min_publish_duration: 0.1

--- a/cob_hardware_config/cob3-2/config/torso.yaml
+++ b/cob_hardware_config/cob3-2/config/torso.yaml
@@ -3,6 +3,7 @@ can_module: PCAN
 can_device: /dev/pcan1
 can_baudrate: 500
 modul_ids: [14,13,24,25]
+module_types: [PW,PW,PW,PW]
 joint_names: [torso_lower_neck_pan_joint,torso_lower_neck_tilt_joint,torso_upper_neck_pan_joint, torso_upper_neck_tilt_joint]
 max_accelerations: [0.8,0.8,0.8,0.8]
 min_publish_duration: 0.1

--- a/cob_hardware_config/cob3-2/config/tray.yaml
+++ b/cob_hardware_config/cob3-2/config/tray.yaml
@@ -2,7 +2,8 @@ can_module: PCAN
 can_device: /dev/pcan1
 can_baudrate: 500
 modul_ids: [10]
-joint_names: [torso_tray_joint]
+module_types: [PRL]
+joint_names: [tray_joint]
 max_accelerations: [0.8]
 min_publish_duration: 0.1
 horizon: 0.1


### PR DESCRIPTION
schunk_powercube_chain  needs modul_typed(PRL, PW) as parameter.
