### PR TITLE
respawn base_velocity_smoother due to frequent crashes, see Trac-Ticket ...

### DIFF
--- a/cob_bringup/components/base.launch
+++ b/cob_bringup/components/base.launch
@@ -20,7 +20,7 @@
 		<include file="$(find cob_undercarriage_ctrl)/ros/launch/undercarriage_ctrl.launch" />
 
 		<!-- start cob_base_velocity_smoother-->
-		<node ns="cob_base_velocity_smoother" pkg="cob_base_velocity_smoother" type="cob_base_velocity_smoother" name="cob_base_velocity_smoother" respawn="false" output="screen">
+		<node ns="cob_base_velocity_smoother" pkg="cob_base_velocity_smoother" type="cob_base_velocity_smoother" name="cob_base_velocity_smoother" respawn="true" output="screen">
 
 			<remap from="input" to="/base_controller/command"/>
 			<remap from="output" to="/base_controller/command_direct"/>


### PR DESCRIPTION
...#354

temporarily "fixes" the problem by respawning the node every time it crashes.

Might lead to small disturbances in the trajectory or stuttering, but does not stop the robot all the time.
