### PR TITLE
Bugfix to pass missing pkg_hardware_config parameter to joy.launch file

### DIFF
--- a/cob_bringup/tools/teleop.launch
+++ b/cob_bringup/tools/teleop.launch
@@ -6,6 +6,7 @@
 
 	<include file="$(find cob_bringup)/components/joy.launch">
 		<arg name="robot" value="$(arg robot)" />
+		<arg name="pkg_hardware_config" value="$(arg pkg_hardware_config)" />
 	</include>
 
 	<node pkg="cob_teleop" type="cob_teleop" name="$(anon teleop_node)" ns="teleop" output="screen">


### PR DESCRIPTION
Bugfix to pass missing pkg_hardware_config parameter to joy.launch file. 
