### PR TITLE
Updates for UniversalRobot on raw3-1

### DIFF
--- a/cob_bringup/drivers/ur.launch
+++ b/cob_bringup/drivers/ur.launch
@@ -6,6 +6,7 @@
  	<!-- universal robot arm -->
 	<node name="ur_driver" ns="arm_controller" pkg="ur_driver" type="driver.py" args="$(arg ur_ip)" output="screen">
 		<remap from="/arm_controller/joint_states" to="/joint_states"/>
+		<remap from="/arm_controller/robot_description" to="/robot_description"/>
 		<param name="prefix" value="arm_"/>
 	</node>
 

--- a/cob_bringup/robots/raw3-1.launch
+++ b/cob_bringup/robots/raw3-1.launch
@@ -8,7 +8,7 @@
 		<arg name="pc1" value="raw3-1-pc1"/>
 		<arg name="pc2" value="raw3-1-pc2"/>
 		<arg name="pc3" value="raw3-1-pc3"/>
-		<arg name="ur_ip" value="192.168.41.40"/>
+		<arg name="ur_ip" value="192.168.141.40"/>
 	</include>
 	
 	<!-- upload default configuration parameters -->


### PR DESCRIPTION
This PR allows to use the universal/ur_driver as it is in the official repository. 
By remapping the parameter, no hacks (i.e. global namespace) in driver.py are required anymore.
This PR is the reason why ros-industrial/universal_robot/pull/46 was closed.
It is not depending on the other PRs 43, 44, 45!
