### PR TITLE
[Indigo] add parameter for max_X_velocity to launch file

### DIFF
--- a/cob_bringup/drivers/base_driver.launch
+++ b/cob_bringup/drivers/base_driver.launch
@@ -11,6 +11,8 @@
 		<param name="IniDirectory" value="$(arg pkg_hardware_config)/$(arg robot)/config/base/"/>
 		<param name="timeout" value="0.2"/>
 		<param name="PublishEffort" value="false"/>
+		<param name="max_trans_velocity" value="1.1"/>	<!-- default: 1.1 m/s -->
+		<param name="max_rot_velocity" value="1.8"/>	<!-- default: 1.8 rad/s -->
 
 		<!-- start underlying components - base_drive_chain -->
 		<node if="$(arg sim)" pkg="cob_base_drive_chain" type="cob_base_drive_chain_sim_node" name="base_drive_chain_node" respawn="false" output="screen"/>


### PR DESCRIPTION
fixes #207 
Adds the parameters to `cob_bringup/drivers/base_driver.launch` file as suggested in #207 
This way, it solves the problem for both simulation and real hardware...

@ipa-frm @ipa-mig 
