### PR TITLE
[Indigo] uses forward command controller for all simulated bases

### DIFF
--- a/cob_controller_configuration_gazebo/controller/base/base_controller_cob3.yaml
+++ b/cob_controller_configuration_gazebo/controller/base/base_controller_cob3.yaml
@@ -1,45 +1,25 @@
-caster_velocity_pid_gains: &caster_velocity_pid_gains
-  p: 8.0
-  d: 0.0
-  i: 0.0
-  i_clamp: 4.0
-
-wheel_pid_gains: &wheel_pid_gains
-  p: 3.0
-  d: 0.0
-  i: 0.0
-  i_clamp: 2.0
-
 base_fr_caster_rotation_controller:
-  type: effort_controllers/JointVelocityController
+  type: velocity_controllers/JointVelocityController
   joint: fr_caster_rotation_joint
-  pid: *caster_velocity_pid_gains
 base_fl_caster_rotation_controller:
-  type: effort_controllers/JointVelocityController
+  type: velocity_controllers/JointVelocityController
   joint: fl_caster_rotation_joint
-  pid: *caster_velocity_pid_gains
 base_br_caster_rotation_controller:
-  type: effort_controllers/JointVelocityController
+  type: velocity_controllers/JointVelocityController
   joint: br_caster_rotation_joint
-  pid: *caster_velocity_pid_gains
 base_bl_caster_rotation_controller:
-  type: effort_controllers/JointVelocityController
+  type: velocity_controllers/JointVelocityController
   joint: bl_caster_rotation_joint
-  pid: *caster_velocity_pid_gains
 base_fr_caster_r_wheel_controller:
-  type: effort_controllers/JointVelocityController
+  type: velocity_controllers/JointVelocityController
   joint: fr_caster_r_wheel_joint
-  pid: *wheel_pid_gains
 base_fl_caster_r_wheel_controller:
-  type: effort_controllers/JointVelocityController
+  type: velocity_controllers/JointVelocityController
   joint: fl_caster_r_wheel_joint
-  pid: *wheel_pid_gains
 base_br_caster_r_wheel_controller:
-  type: effort_controllers/JointVelocityController
+  type: velocity_controllers/JointVelocityController
   joint: br_caster_r_wheel_joint
-  pid: *wheel_pid_gains
 base_bl_caster_r_wheel_controller:
-  type: effort_controllers/JointVelocityController
+  type: velocity_controllers/JointVelocityController
   joint: bl_caster_r_wheel_joint
-  pid: *wheel_pid_gains  
 

--- a/cob_controller_configuration_gazebo/controller/base/base_controller_cob4.yaml
+++ b/cob_controller_configuration_gazebo/controller/base/base_controller_cob4.yaml
@@ -1,36 +1,18 @@
-caster_velocity_pid_gains: &caster_velocity_pid_gains
-  p: 8.0
-  d: 0.0
-  i: 0.0
-  i_clamp: 4.0
-
-wheel_pid_gains: &wheel_pid_gains
-  p: 3.0
-  d: 0.0
-  i: 0.0
-  i_clamp: 2.0
-
 base_fl_caster_rotation_controller:
-  type: effort_controllers/JointVelocityController
+  type: velocity_controllers/JointVelocityController
   joint: fl_caster_rotation_joint
-  pid: *caster_velocity_pid_gains
 base_bl_caster_rotation_controller:
-  type: effort_controllers/JointVelocityController
+  type: velocity_controllers/JointVelocityController
   joint: bl_caster_rotation_joint
-  pid: *caster_velocity_pid_gains
 base_br_caster_rotation_controller:
-  type: effort_controllers/JointVelocityController
+  type: velocity_controllers/JointVelocityController
   joint: br_caster_rotation_joint
-  pid: *caster_velocity_pid_gains
 base_fl_caster_r_wheel_controller:
-  type: effort_controllers/JointVelocityController
+  type: velocity_controllers/JointVelocityController
   joint: fl_caster_r_wheel_joint
-  pid: *wheel_pid_gains
 base_bl_caster_r_wheel_controller:
-  type: effort_controllers/JointVelocityController
+  type: velocity_controllers/JointVelocityController
   joint: bl_caster_r_wheel_joint
-  pid: *wheel_pid_gains
 base_br_caster_r_wheel_controller:
-  type: effort_controllers/JointVelocityController
+  type: velocity_controllers/JointVelocityController
   joint: br_caster_r_wheel_joint
-  pid: *wheel_pid_gains  


### PR DESCRIPTION
Merge together with [cob_common#131](https://github.com/ipa320/cob_common/pull/131)

This PR improves simulated Odometry with a factor of about 10...especially when a "Zero-Twist" is sent, i.e. base should not move at all.

@ipa-mig and others from the Nav-Team please review (do you have students working with simulation?)
