### PR TITLE
set interpolation perdiod to sync interval (10ms/100Hz)

### DIFF
--- a/cob_hardware_config/common/Elmo.dcf
+++ b/cob_hardware_config/common/Elmo.dcf
@@ -2527,6 +2527,7 @@ ObjectType=0x7
 DataType=0x0005
 AccessType=rw
 DefaultValue=1
+ParameterValue=10
 PDOMapping=0
 LowLimit=1
 HighLimit=255

--- a/cob_hardware_config/common/Schunk_0_63.dcf
+++ b/cob_hardware_config/common/Schunk_0_63.dcf
@@ -1439,7 +1439,7 @@ DataType=0x0005
 AccessType=rw
 DefaultValue=8
 PDOMapping=0
-ParameterValue=50
+ParameterValue=10
 
 [60C2sub2]
 ParameterName=interpolation_time_period_index


### PR DESCRIPTION
Elmo period was too low (-> buffer underrun), Schunk period is quite high.
Needs to be tested on real hardware (Schunk+Elmo).
Maybe we should increase it to relax jitter problems, but this may lead to problems with full buffers.
