### PR TITLE
remap diagnostics for cob_head_axis

### DIFF
--- a/cob_bringup/drivers/head_axis.launch
+++ b/cob_bringup/drivers/head_axis.launch
@@ -7,6 +7,7 @@
 	<node ns="head" pkg="cob_head_axis" type="cob_head_axis_node" name="cob_head_axis_node" cwd="node" respawn="false" output="screen" >
 		<param name="CanIniFile" value="$(arg pkg_hardware_config)/$(arg robot)/config/head_driver.ini" />
 		<rosparam command="load" file="$(arg pkg_hardware_config)/$(arg robot)/config/head_driver.yaml"/>
+		<remap from="diagnostics" to="/diagnostics"/>
 	</node>
 
 	<!-- robot_state_publisher -->


### PR DESCRIPTION
This is related to https://github.com/ipa320/cob_driver/pull/215
As discussed there, an appropriate remap is more desirable than a hard-coded namespace

@jobstvogt FYI
