### PR TITLE
Restructure cartesian parameter layout

### DIFF
--- a/cob_hardware_config/cob4-1/config/arm_left_cartesian_controller.yaml
+++ b/cob_hardware_config/cob4-1/config/arm_left_cartesian_controller.yaml
@@ -1,8 +1,7 @@
-## Cartesian controller
-cartesian_controller:
-  update_rate: 50.0
+## Cartesian controller parameters
 
-  # twist controller parameters
+# twist controller parameters
+twist_controller:
   chain_base_link: arm_left_base_link
   chain_tip_link: arm_left_7_link
   base_compensation: false
@@ -14,16 +13,25 @@ cartesian_controller:
   max_vel_rot_base: 0.5
 
   # damping parameters
-  damping_method: 0  #MANIPULABILITY
+  damping_method: 2  #MANIPULABILITY
   damping_factor: 0.2
   lambda0: 0.1
   wt: 0.005
-  
-  JLA_active: true 
-  enforce_limits: true
+  # constraints and truncation
+  constraint: 2 #WLN_JLA
+  eps: 0.03     #TRUNCATION
+  # limit enforcing
+  keep_direction: true
+  enforce_vel_limits: true
+  enforce_pos_limits: true
   tolerance: 5.0 
 
-  # frame_tracker + interactive_marker
+# frame_tracker + interactive_marker
+frame_tracker:
+  update_rate: 50.0
+
+  chain_base_link: arm_left_base_link
+  chain_tip_link: arm_left_7_link
   tracking_frame: arm_left_7_target
   root_frame: odom_combined
   movable_trans: true
@@ -34,3 +42,10 @@ cartesian_controller:
   pid_rot_x: {p: 4.0, i: 0.0, d: 0.0, i_clamp: 0.0}
   pid_rot_y: {p: 4.0, i: 0.0, d: 0.0, i_clamp: 0.0}
   pid_rot_z: {p: 4.0, i: 0.0, d: 0.0, i_clamp: 0.0}
+  # abortion criteria - cfg
+  cart_min_dist_threshold_lin: 0.042
+  cart_min_dist_threshold_rot: 0.01
+  twist_dead_threshold_lin: 0.05
+  twist_dead_threshold_rot: 0.05
+  twist_deviation_threshold_lin: 0.5
+  twist_deviation_threshold_rot: 0.5

--- a/cob_hardware_config/cob4-1/config/arm_right_cartesian_controller.yaml
+++ b/cob_hardware_config/cob4-1/config/arm_right_cartesian_controller.yaml
@@ -1,8 +1,7 @@
-## Cartesian controller
-cartesian_controller:
-  update_rate: 50.0
+## Cartesian controller parameters
 
-  # twist controller parameters
+# twist controller parameters
+twist_controller:
   chain_base_link: arm_right_base_link
   chain_tip_link: arm_right_7_link
   base_compensation: false
@@ -14,16 +13,25 @@ cartesian_controller:
   max_vel_rot_base: 0.5
 
   # damping parameters
-  damping_method: 0  #MANIPULABILITY
+  damping_method: 2  #MANIPULABILITY
   damping_factor: 0.2
   lambda0: 0.1
   wt: 0.005
-  
-  JLA_active: true 
-  enforce_limits: true
+  # constraints and truncation
+  constraint: 2 #WLN_JLA
+  eps: 0.03     #TRUNCATION
+  # limit enforcing
+  keep_direction: true
+  enforce_vel_limits: true
+  enforce_pos_limits: true
   tolerance: 5.0 
 
-  # frame_tracker + interactive_marker
+# frame_tracker + interactive_marker
+frame_tracker:
+  update_rate: 50.0
+
+  chain_base_link: arm_right_base_link
+  chain_tip_link: arm_right_7_link
   tracking_frame: arm_right_7_target
   root_frame: odom_combined
   movable_trans: true
@@ -34,3 +42,10 @@ cartesian_controller:
   pid_rot_x: {p: 4.0, i: 0.0, d: 0.0, i_clamp: 0.0}
   pid_rot_y: {p: 4.0, i: 0.0, d: 0.0, i_clamp: 0.0}
   pid_rot_z: {p: 4.0, i: 0.0, d: 0.0, i_clamp: 0.0}
+  # abortion criteria - cfg
+  cart_min_dist_threshold_lin: 0.01
+  cart_min_dist_threshold_rot: 0.01
+  twist_dead_threshold_lin: 0.05
+  twist_dead_threshold_rot: 0.05
+  twist_deviation_threshold_lin: 0.5
+  twist_deviation_threshold_rot: 0.5

--- a/cob_hardware_config/cob4-1/config/head_cartesian_controller.yaml
+++ b/cob_hardware_config/cob4-1/config/head_cartesian_controller.yaml
@@ -1,8 +1,7 @@
-## Cartesian controller
-cartesian_controller:
-  update_rate: 50.0
+## Cartesian controller parameters
 
-  # twist controller parameters
+# twist controller parameters
+twist_controller:
   chain_base_link: head_base_link
   chain_tip_link: head_center_link
   base_compensation: false
@@ -14,16 +13,25 @@ cartesian_controller:
   max_vel_rot_base: 0.5
 
   # damping parameters
-  damping_method: 0  #MANIPULABILITY
+  damping_method: 2  #MANIPULABILITY
   damping_factor: 0.2
   lambda0: 0.1
   wt: 0.005
-  
-  JLA_active: true 
-  enforce_limits: true
+  # constraints and truncation
+  constraint: 2 #WLN_JLA
+  eps: 0.03     #TRUNCATION
+  # limit enforcing
+  keep_direction: true
+  enforce_vel_limits: true
+  enforce_pos_limits: true
   tolerance: 5.0 
 
-  # frame_tracker + interactive_marker
+# frame_tracker + interactive_marker
+frame_tracker:
+  update_rate: 50.0
+
+  chain_base_link: head_base_link
+  chain_tip_link: head_center_link
   tracking_frame: head_center_target
   root_frame: odom_combined
   movable_trans: false
@@ -34,3 +42,10 @@ cartesian_controller:
   pid_rot_x: {p: 4.0, i: 0.0, d: 0.0, i_clamp: 0.0}
   pid_rot_y: {p: 4.0, i: 0.0, d: 0.0, i_clamp: 0.0}
   pid_rot_z: {p: 4.0, i: 0.0, d: 0.0, i_clamp: 0.0}
+  # abortion criteria - cfg
+  cart_min_dist_threshold_lin: 0.01
+  cart_min_dist_threshold_rot: 0.01
+  twist_dead_threshold_lin: 0.05
+  twist_dead_threshold_rot: 0.05
+  twist_deviation_threshold_lin: 0.5
+  twist_deviation_threshold_rot: 0.5

--- a/cob_hardware_config/cob4-1/config/torso_cartesian_controller.yaml
+++ b/cob_hardware_config/cob4-1/config/torso_cartesian_controller.yaml
@@ -1,8 +1,7 @@
-## Cartesian controller
-cartesian_controller:
-  update_rate: 50.0
+## Cartesian controller parameters
 
-  # twist controller parameters
+# twist controller parameters
+twist_controller:
   chain_base_link: torso_base_link
   chain_tip_link: torso_center_link
   base_compensation: false
@@ -14,16 +13,25 @@ cartesian_controller:
   max_vel_rot_base: 0.5
 
   # damping parameters
-  damping_method: 0  #MANIPULABILITY
+  damping_method: 2  #MANIPULABILITY
   damping_factor: 0.2
   lambda0: 0.1
   wt: 0.005
-  
-  JLA_active: true 
-  enforce_limits: true
+  # constraints and truncation
+  constraint: 2 #WLN_JLA
+  eps: 0.03     #TRUNCATION
+  # limit enforcing
+  keep_direction: true
+  enforce_vel_limits: true
+  enforce_pos_limits: true
   tolerance: 5.0 
 
-  # frame_tracker + interactive_marker
+# frame_tracker + interactive_marker
+frame_tracker:
+  update_rate: 50.0
+
+  chain_base_link: torso_base_link
+  chain_tip_link: torso_center_link
   tracking_frame: torso_center_target
   root_frame: odom_combined
   movable_trans: false
@@ -34,3 +42,10 @@ cartesian_controller:
   pid_rot_x: {p: 4.0, i: 0.0, d: 0.0, i_clamp: 0.0}
   pid_rot_y: {p: 4.0, i: 0.0, d: 0.0, i_clamp: 0.0}
   pid_rot_z: {p: 4.0, i: 0.0, d: 0.0, i_clamp: 0.0}
+  # abortion criteria - cfg
+  cart_min_dist_threshold_lin: 0.01
+  cart_min_dist_threshold_rot: 0.01
+  twist_dead_threshold_lin: 0.05
+  twist_dead_threshold_rot: 0.05
+  twist_deviation_threshold_lin: 0.5
+  twist_deviation_threshold_rot: 0.5

--- a/cob_hardware_config/cob4-2/config/arm_left_cartesian_controller.yaml
+++ b/cob_hardware_config/cob4-2/config/arm_left_cartesian_controller.yaml
@@ -1,8 +1,7 @@
-## Cartesian controller
-cartesian_controller:
-  update_rate: 50.0
+## Cartesian controller parameters
 
-  # twist controller parameters
+# twist controller parameters
+twist_controller:
   chain_base_link: arm_left_base_link
   chain_tip_link: arm_left_7_link
   base_compensation: false
@@ -14,16 +13,25 @@ cartesian_controller:
   max_vel_rot_base: 0.5
 
   # damping parameters
-  damping_method: 0  #MANIPULABILITY
+  damping_method: 2  #MANIPULABILITY
   damping_factor: 0.2
   lambda0: 0.1
   wt: 0.005
-  
-  JLA_active: true 
-  enforce_limits: true
+  # constraints and truncation
+  constraint: 2 #WLN_JLA
+  eps: 0.03     #TRUNCATION
+  # limit enforcing
+  keep_direction: true
+  enforce_vel_limits: true
+  enforce_pos_limits: true
   tolerance: 5.0 
 
-  # frame_tracker + interactive_marker
+# frame_tracker + interactive_marker
+frame_tracker:
+  update_rate: 50.0
+
+  chain_base_link: arm_left_base_link
+  chain_tip_link: arm_left_7_link
   tracking_frame: arm_left_7_target
   root_frame: odom_combined
   movable_trans: true
@@ -34,3 +42,10 @@ cartesian_controller:
   pid_rot_x: {p: 4.0, i: 0.0, d: 0.0, i_clamp: 0.0}
   pid_rot_y: {p: 4.0, i: 0.0, d: 0.0, i_clamp: 0.0}
   pid_rot_z: {p: 4.0, i: 0.0, d: 0.0, i_clamp: 0.0}
+  # abortion criteria - cfg
+  cart_min_dist_threshold_lin: 0.042
+  cart_min_dist_threshold_rot: 0.01
+  twist_dead_threshold_lin: 0.05
+  twist_dead_threshold_rot: 0.05
+  twist_deviation_threshold_lin: 0.5
+  twist_deviation_threshold_rot: 0.5

--- a/cob_hardware_config/cob4-2/config/arm_right_cartesian_controller.yaml
+++ b/cob_hardware_config/cob4-2/config/arm_right_cartesian_controller.yaml
@@ -1,8 +1,7 @@
-## Cartesian controller
-cartesian_controller:
-  update_rate: 50.0
+## Cartesian controller parameters
 
-  # twist controller parameters
+# twist controller parameters
+twist_controller:
   chain_base_link: arm_right_base_link
   chain_tip_link: arm_right_7_link
   base_compensation: false
@@ -14,16 +13,25 @@ cartesian_controller:
   max_vel_rot_base: 0.5
 
   # damping parameters
-  damping_method: 0  #MANIPULABILITY
+  damping_method: 2  #MANIPULABILITY
   damping_factor: 0.2
   lambda0: 0.1
   wt: 0.005
-  
-  JLA_active: true 
-  enforce_limits: true
+  # constraints and truncation
+  constraint: 2 #WLN_JLA
+  eps: 0.03     #TRUNCATION
+  # limit enforcing
+  keep_direction: true
+  enforce_vel_limits: true
+  enforce_pos_limits: true
   tolerance: 5.0 
 
-  # frame_tracker + interactive_marker
+# frame_tracker + interactive_marker
+frame_tracker:
+  update_rate: 50.0
+
+  chain_base_link: arm_right_base_link
+  chain_tip_link: arm_right_7_link
   tracking_frame: arm_right_7_target
   root_frame: odom_combined
   movable_trans: true
@@ -34,3 +42,10 @@ cartesian_controller:
   pid_rot_x: {p: 4.0, i: 0.0, d: 0.0, i_clamp: 0.0}
   pid_rot_y: {p: 4.0, i: 0.0, d: 0.0, i_clamp: 0.0}
   pid_rot_z: {p: 4.0, i: 0.0, d: 0.0, i_clamp: 0.0}
+  # abortion criteria - cfg
+  cart_min_dist_threshold_lin: 0.01
+  cart_min_dist_threshold_rot: 0.01
+  twist_dead_threshold_lin: 0.05
+  twist_dead_threshold_rot: 0.05
+  twist_deviation_threshold_lin: 0.5
+  twist_deviation_threshold_rot: 0.5

--- a/cob_hardware_config/cob4-2/config/torso_cartesian_controller.yaml
+++ b/cob_hardware_config/cob4-2/config/torso_cartesian_controller.yaml
@@ -1,8 +1,7 @@
-## Cartesian controller
-cartesian_controller:
-  update_rate: 50.0
+## Cartesian controller parameters
 
-  # twist controller parameters
+# twist controller parameters
+twist_controller:
   chain_base_link: torso_base_link
   chain_tip_link: torso_center_link
   base_compensation: false
@@ -14,16 +13,25 @@ cartesian_controller:
   max_vel_rot_base: 0.5
 
   # damping parameters
-  damping_method: 0  #MANIPULABILITY
+  damping_method: 2  #MANIPULABILITY
   damping_factor: 0.2
   lambda0: 0.1
   wt: 0.005
-  
-  JLA_active: true 
-  enforce_limits: true
+  # constraints and truncation
+  constraint: 2 #WLN_JLA
+  eps: 0.03     #TRUNCATION
+  # limit enforcing
+  keep_direction: true
+  enforce_vel_limits: true
+  enforce_pos_limits: true
   tolerance: 5.0 
 
-  # frame_tracker + interactive_marker
+# frame_tracker + interactive_marker
+frame_tracker:
+  update_rate: 50.0
+
+  chain_base_link: torso_base_link
+  chain_tip_link: torso_center_link
   tracking_frame: torso_center_target
   root_frame: odom_combined
   movable_trans: false
@@ -34,3 +42,10 @@ cartesian_controller:
   pid_rot_x: {p: 4.0, i: 0.0, d: 0.0, i_clamp: 0.0}
   pid_rot_y: {p: 4.0, i: 0.0, d: 0.0, i_clamp: 0.0}
   pid_rot_z: {p: 4.0, i: 0.0, d: 0.0, i_clamp: 0.0}
+  # abortion criteria - cfg
+  cart_min_dist_threshold_lin: 0.01
+  cart_min_dist_threshold_rot: 0.01
+  twist_dead_threshold_lin: 0.05
+  twist_dead_threshold_rot: 0.05
+  twist_deviation_threshold_lin: 0.5
+  twist_deviation_threshold_rot: 0.5


### PR DESCRIPTION
configures the cartesian controller parameters according to the new layout proposed in https://github.com/ipa320/cob_control/pull/35

builds on top of #296 
