### PR TITLE
fix run dependency

### DIFF
--- a/cob_bringup/package.xml
+++ b/cob_bringup/package.xml
@@ -68,6 +68,7 @@
   <run_depend>cob_frame_tracker</run_depend>
   <run_depend>cob_trajectory_controller</run_depend>
   <run_depend>cob_twist_controller</run_depend>
+  <run_depend>joint_state_publisher</run_depend>
   <run_depend>joint_state_controller</run_depend>
   <run_depend>position_controllers</run_depend>
   <run_depend>velocity_controllers</run_depend>


### PR DESCRIPTION
As detected by running `catkin_make test`

```
<?xml version="1.0" encoding="UTF-8"?>
<testsuite tests="1" failures="1" time="1" errors="0" name="roslaunch-check_robots_cob4-1.xml.xml">
  <testcase name="test_ran" status="run" time="1" classname="Results">
  <failure message="roslaunch check [/home/fxm/projects/indigo/care-o-bot/src/cob_robots/cob_bringup/robots/cob4-1.xml] failed" type=""/>
  </testcase>
  <system-out><![CDATA[[
[/home/fxm/projects/indigo/care-o-bot/src/cob_robots/cob_bringup/robots/cob4-1.xml]:
        Missing manifest dependencies: cob_bringup/manifest.xml: joint_state_publisher
]]></system-out>
</testsuite>
```
