### PR TITLE
fixes for cob3-9

### DIFF
--- a/cob_hardware_config/cob3-2/config/light.yaml
+++ b/cob_hardware_config/cob3-2/config/light.yaml
@@ -4,5 +4,6 @@ baudrate: 230400
 num_leds: 1
 invert_output: false
 pubmarker: true
+marker_frame: /base_link # marker will be publised at [0.5,0,0] with respect to marker_frame
 startup_color: [0.0, 1.0, 0.0, 1.0] #rgba value
 startup_mode: Static #possible values: None, Static, Breath, BreathColor, Flash, FadeColor

--- a/cob_hardware_config/cob3-6/config/light.yaml
+++ b/cob_hardware_config/cob3-6/config/light.yaml
@@ -4,5 +4,6 @@ baudrate: 230400
 num_leds: 1
 invert_output: false
 pubmarker: true
+marker_frame: /base_link # marker will be publised at [0.5,0,0] with respect to marker_frame
 startup_color: [0.0, 1.0, 0.0, 1.0] #rgba value
 startup_mode: Static #possible values: None, Static, Breath, BreathColor, Flash, FadeColor

--- a/cob_hardware_config/cob3-9/config/footprint_observer_params.yaml
+++ b/cob_hardware_config/cob3-9/config/footprint_observer_params.yaml
@@ -4,5 +4,5 @@ footprint_source: /local_costmap_node/costmap
 #
 robot_base_frame: /base_link
 # frames to check for footprint adjustment
-frames_to_check: /pg70_finger_left_joint /arm_6_link /arm_4_link /tray_right_link /tray_left_link
+frames_to_check: /pg70_finger_left_link /arm_6_link /arm_4_link /tray_right_link /tray_left_link
 epsilon: 0.01

--- a/cob_hardware_config/cob3-9/config/gripper_controller.yaml
+++ b/cob_hardware_config/cob3-9/config/gripper_controller.yaml
@@ -1,5 +1,5 @@
 ## joint_names
-joint_names: [pg70_finger_left_joint]
+joint_names: [pg70_finger_left_joint, pg70_finger_right_joint]
 
 ## control_mode_adapter
 max_command_silence: 0.5

--- a/cob_hardware_config/cob3-9/config/light.yaml
+++ b/cob_hardware_config/cob3-9/config/light.yaml
@@ -4,6 +4,7 @@ baudrate: 230400
 num_leds: 1
 invert_output: false
 pubmarker: true
+marker_frame: /base_link # marker will be publised at [0.5,0,0] with respect to marker_frame
 sim_enabled: false
 startup_color: [0.0, 1.0, 0.0, 1.0] #rgba value
 startup_mode: Static #possible values: None, Static, Breath, BreathColor, Flash, FadeColor

--- a/cob_hardware_config/cob4-4/config/light_base.yaml
+++ b/cob_hardware_config/cob4-4/config/light_base.yaml
@@ -4,5 +4,6 @@ baudrate: 38400
 num_leds: 3
 invert_output: false
 pubmarker: true
+marker_frame: /base_link # marker will be publised at [0.5,0,0] with respect to marker_frame
 startup_color: [0.0, 1.0, 0.5, 0.4] #rgba value
 startup_mode: Static #possible values: None, Static, Breath, BreathColor, Flash, FadeColor

--- a/cob_hardware_config/cob4-6/config/light_base.yaml
+++ b/cob_hardware_config/cob4-6/config/light_base.yaml
@@ -4,5 +4,6 @@ baudrate: 38400
 num_leds: 3
 invert_output: false
 pubmarker: true
+marker_frame: /base_link # marker will be publised at [0.5,0,0] with respect to marker_frame
 startup_color: [0.0, 1.0, 0.5, 0.4] #rgba value
 startup_mode: Static #possible values: None, Static, Breath, BreathColor, Flash, FadeColor

--- a/cob_hardware_config/raw3-1/config/light.yaml
+++ b/cob_hardware_config/raw3-1/config/light.yaml
@@ -2,5 +2,6 @@ devicestring: /dev/ttyUSB0
 baudrate: 230400
 invert_output: true
 pubmarker: false
+marker_frame: /base_link # marker will be publised at [0.5,0,0] with respect to marker_frame
 startup_color: [0.0, 0.0, 0.0, 0.0] #rgba value
 startup_mode: None #possible values: None, Static, Breath, BreathColor, Flash, FadeColor

--- a/cob_hardware_config/raw3-3/config/light.yaml
+++ b/cob_hardware_config/raw3-3/config/light.yaml
@@ -3,5 +3,6 @@ devicestring: /dev/ttyUSB0
 baudrate: 38400
 invert_output: false
 pubmarker: false
+marker_frame: /base_link # marker will be publised at [0.5,0,0] with respect to marker_frame
 startup_color: [0.0, 1.0, 0.0, 1.0] #rgba value
 startup_mode: Static #possible values: None, Static, Breath, BreathColor, Flash...


### PR DESCRIPTION
- missing parameters in cob_light
- wrong parameters in footprint_observer
- fixes gripper_controller for pg70

related to https://github.com/ipa320/cob_simulation/issues/87
@xwhm
