### PR TITLE
making 'sim_enabled' a launch argument

### DIFF
--- a/cob_bringup/drivers/light.launch
+++ b/cob_bringup/drivers/light.launch
@@ -4,10 +4,12 @@
 	<arg name="robot" default="$(optenv ROBOT !!NO_ROBOT_SET!!)"/>
 	<arg name="pkg_hardware_config" default="$(find cob_hardware_config)"/>
 	<arg name="component_name" default="light"/>
+	<arg name="sim_enabled" default="false"/>
 
 	<!-- start light controller -->
 	<node pkg="cob_light" type="cob_light" name="$(arg component_name)" respawn="false" output="screen" >
 		<rosparam command="load" file="$(arg pkg_hardware_config)/$(arg robot)/config/$(arg component_name).yaml"/>
+		<param name="sim_enabled" value="$(arg sim_enabled)"/>
 	</node>
 
 </launch>

--- a/cob_controller_configuration_gazebo/launch/robots/default_controllers_cob3-2.launch
+++ b/cob_controller_configuration_gazebo/launch/robots/default_controllers_cob3-2.launch
@@ -84,6 +84,7 @@
 	<include file="$(find cob_bringup)/drivers/light.launch" >
 		<arg name="robot" value="$(arg robot)"/>
 		<arg name="component_name" value="light"/>
+		<arg name="sim_enabled" value="true"/>
 	</include>
 	<include file="$(find cob_bringup)/tools/base_collision_observer.launch" >
 		<arg name="robot" value="$(arg robot)"/>

--- a/cob_controller_configuration_gazebo/launch/robots/default_controllers_cob3-6.launch
+++ b/cob_controller_configuration_gazebo/launch/robots/default_controllers_cob3-6.launch
@@ -84,6 +84,7 @@
 	<include file="$(find cob_bringup)/drivers/light.launch" >
 		<arg name="robot" value="$(arg robot)"/>
 		<arg name="component_name" value="light"/>
+		<arg name="sim_enabled" value="true"/>
 	</include>
 	<include file="$(find cob_bringup)/tools/base_collision_observer.launch" >
 		<arg name="robot" value="$(arg robot)"/>

--- a/cob_controller_configuration_gazebo/launch/robots/default_controllers_cob3-9.launch
+++ b/cob_controller_configuration_gazebo/launch/robots/default_controllers_cob3-9.launch
@@ -84,6 +84,7 @@
 	<include file="$(find cob_bringup)/drivers/light.launch" >
 		<arg name="robot" value="$(arg robot)"/>
 		<arg name="component_name" value="light"/>
+		<arg name="sim_enabled" value="true"/>
 	</include>
 	<include file="$(find cob_bringup)/tools/base_collision_observer.launch" >
 		<arg name="robot" value="$(arg robot)"/>

--- a/cob_hardware_config/cob3-2/config/light.yaml
+++ b/cob_hardware_config/cob3-2/config/light.yaml
@@ -4,6 +4,5 @@ baudrate: 230400
 num_leds: 1
 invert_output: false
 pubmarker: true
-sim_enabled: false
 startup_color: [0.0, 1.0, 0.0, 1.0] #rgba value
 startup_mode: Static #possible values: None, Static, Breath, BreathColor, Flash, FadeColor

--- a/cob_hardware_config/cob3-6/config/light.yaml
+++ b/cob_hardware_config/cob3-6/config/light.yaml
@@ -4,6 +4,5 @@ baudrate: 230400
 num_leds: 1
 invert_output: false
 pubmarker: true
-sim_enabled: false
 startup_color: [0.0, 1.0, 0.0, 1.0] #rgba value
 startup_mode: Static #possible values: None, Static, Breath, BreathColor, Flash, FadeColor

--- a/cob_hardware_config/cob3-9/config/light.yaml
+++ b/cob_hardware_config/cob3-9/config/light.yaml
@@ -4,6 +4,5 @@ baudrate: 230400
 num_leds: 1
 invert_output: false
 pubmarker: true
-sim_enabled: false
 startup_color: [0.0, 1.0, 0.0, 1.0] #rgba value
 startup_mode: Static #possible values: None, Static, Breath, BreathColor, Flash, FadeColor

--- a/cob_hardware_config/cob4-2/config/light_base.yaml
+++ b/cob_hardware_config/cob4-2/config/light_base.yaml
@@ -5,6 +5,5 @@ num_leds: 3
 invert_output: false
 pubmarker: true
 marker_frame: /torso_base_link # marker will be publised at [0.5,0,0] with respect to marker_frame
-sim_enabled: false
 startup_color: [0.0, 1.0, 0.5, 0.4] #rgba value
 startup_mode: Static #possible values: None, Static, Breath, BreathColor, Flash, FadeColor

--- a/cob_hardware_config/cob4-2/config/light_torso.yaml
+++ b/cob_hardware_config/cob4-2/config/light_torso.yaml
@@ -5,6 +5,5 @@ num_leds: 58
 invert_output: false
 pubmarker: true
 marker_frame: /torso_center_link # marker will be publised at [0.5,0,0] with respect to marker_frame
-sim_enabled: false
 startup_color: [0.0, 1.0, 0.7, 0.4] #rgba value
 startup_mode: Breath #possible values: None, Static, Breath, BreathColor, Flash, FadeColor

--- a/cob_hardware_config/cob4-4/config/light_base.yaml
+++ b/cob_hardware_config/cob4-4/config/light_base.yaml
@@ -4,6 +4,5 @@ baudrate: 38400
 num_leds: 3
 invert_output: false
 pubmarker: true
-sim_enabled: false
 startup_color: [0.0, 1.0, 0.5, 0.4] #rgba value
 startup_mode: Static #possible values: None, Static, Breath, BreathColor, Flash, FadeColor

--- a/cob_hardware_config/cob4-6/config/light_base.yaml
+++ b/cob_hardware_config/cob4-6/config/light_base.yaml
@@ -4,6 +4,5 @@ baudrate: 38400
 num_leds: 3
 invert_output: false
 pubmarker: true
-sim_enabled: false
 startup_color: [0.0, 1.0, 0.5, 0.4] #rgba value
 startup_mode: Static #possible values: None, Static, Breath, BreathColor, Flash, FadeColor

--- a/cob_hardware_config/raw3-1/config/light.yaml
+++ b/cob_hardware_config/raw3-1/config/light.yaml
@@ -2,6 +2,5 @@ devicestring: /dev/ttyUSB0
 baudrate: 230400
 invert_output: true
 pubmarker: false
-sim_enabled: false
 startup_color: [0.0, 0.0, 0.0, 0.0] #rgba value
 startup_mode: None #possible values: None, Static, Breath, BreathColor, Flash, FadeColor

--- a/cob_hardware_config/raw3-3/config/light.yaml
+++ b/cob_hardware_config/raw3-3/config/light.yaml
@@ -3,6 +3,5 @@ devicestring: /dev/ttyUSB0
 baudrate: 38400
 invert_output: false
 pubmarker: false
-sim_enabled: false
 startup_color: [0.0, 1.0, 0.0, 1.0] #rgba value
 startup_mode: Static #possible values: None, Static, Breath, BreathColor, Flash...


### PR DESCRIPTION
@ipa-bnm 

allows to start simulation without Warning

> Serial connection on %s failed

fixes https://github.com/ipa320/cob_driver/issues/236

related to https://github.com/ipa320/cob_simulation/issues/87
@xwhm
