### PR TITLE
do not respawn phidgets driver

### DIFF
--- a/cob_bringup/drivers/phidgets.launch
+++ b/cob_bringup/drivers/phidgets.launch
@@ -4,7 +4,7 @@
 	<arg name="robot" default="$(optenv ROBOT !!NO_ROBOT_SET!!)"/>
 	<arg name="pkg_hardware_config" default="$(find cob_hardware_config)"/>
 
-	<node pkg="cob_phidgets" type="phidget_sensors" name="phidgets" cwd="node" respawn="true" output="screen">
+	<node pkg="cob_phidgets" type="phidget_sensors" name="phidgets" cwd="node" respawn="false" output="screen">
 		<rosparam file="$(arg pkg_hardware_config)/$(arg robot)/config/phidgets.yaml" command="load" />
 	</node>
 


### PR DESCRIPTION
because if no phidget is connected the driver will restart all the time
