### PR TITLE
removed leading / from tf frame names. 

### DIFF
--- a/cob_bringup/drivers/openni.launch
+++ b/cob_bringup/drivers/openni.launch
@@ -13,8 +13,8 @@
 	<include file="$(find openni_launch)/launch/openni.launch">
 		<arg name="camera" value="$(arg name)"/>
 		<arg name="device_id" value="$(arg device_id)" />
-		<arg name="rgb_frame_id" value="/$(arg name)_link" />
-		<arg name="depth_frame_id" value="/$(arg name)_link" />
+		<arg name="rgb_frame_id" value="$(arg name)_link" />
+		<arg name="depth_frame_id" value="$(arg name)_link" />
 		<arg name="publish_tf" value="false" />
 		<arg name="rgb_camera_info_url" value="file:///$(find cob_calibration_data)/$(arg robot)/calibration/cameras/$(arg name).yaml" />
 	</include>

--- a/cob_bringup/drivers/openni2.launch
+++ b/cob_bringup/drivers/openni2.launch
@@ -13,8 +13,8 @@
 	<include file="$(find openni2_launch)/launch/openni2.launch">
 		<arg name="camera" value="$(arg name)"/>
 		<arg name="device_id" value="$(arg device_id)" />
-		<arg name="rgb_frame_id" value="/$(arg name)_link" />
-		<arg name="depth_frame_id" value="/$(arg name)_link" />
+		<arg name="rgb_frame_id" value="$(arg name)_link" />
+		<arg name="depth_frame_id" value="$(arg name)_link" />
 		<arg name="publish_tf" value="false" />
 		<arg name="depth_registration" value="true"/>
 		<arg name="rgb_camera_info_url" value="file:///$(find cob_calibration_data)/$(arg robot)/calibration/cameras/$(arg name).yaml" />


### PR DESCRIPTION
They are no longer supported in tf2.
If you use a tf2 you will get the following error if you use leading slash in tf name:
`Transform failure: Invalid argument "/torso_cam3d_left_link" passed to lookupTransform argument source_frame in tf2 frame_ids cannot start with a '/' like`
