### PR TITLE
[WIP] add sensorring sensors within cob_hardware_config

### DIFF
--- a/cob_hardware_config/cob4-2/urdf/cob4-2.sensors.xacro
+++ b/cob_hardware_config/cob4-2/urdf/cob4-2.sensors.xacro
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
+
+  <!-- sensorring sensors -->
+  <xacro:include filename="$(find cob_description)/urdf/sensors/kinect.urdf.xacro" />
+
+  <xacro:cob_kinect_v0 name="sensorring_cam3d" ros_topic="sensorring_cam3d" parent="sensorring_link">
+    <origin xyz="${sensorring_cam3d_x} ${sensorring_cam3d_y} ${sensorring_cam3d_z}" rpy="${sensorring_cam3d_roll} ${sensorring_cam3d_pitch} ${sensorring_cam3d_yaw}" />
+  </xacro:cob_kinect_v0>
+
+</robot>

--- a/cob_hardware_config/cob4-2/urdf/cob4-2.urdf.xacro
+++ b/cob_hardware_config/cob4-2/urdf/cob4-2.urdf.xacro
@@ -10,6 +10,9 @@
   <!-- calibration -->
   <xacro:include filename="$(find cob_hardware_config)/cob4-2/urdf/properties.urdf.xacro" />
 
+  <!-- additional sensors -->
+  <xacro:include filename="$(find cob_hardware_config)/cob4-2/urdf/cob4-2.sensors.xacro" />
+
   <!-- base -->
   <xacro:include filename="$(find cob_description)/urdf/cob4_base/base.urdf.xacro" />
 
@@ -26,7 +29,7 @@
   <xacro:include filename="$(find cob_description)/urdf/cob4_head/head_static.urdf.xacro" />
 
   <!-- sensorring -->
-  <xacro:include filename="$(find cob_description)/urdf/cob4_sensorring/sensorring_asus.urdf.xacro" />
+  <xacro:include filename="$(find cob_description)/urdf/cob4_sensorring/sensorring.urdf.xacro" />
 
   <!-- composition of the robot -->
   <xacro:base name="base" use_old_joint_names="true"/>


### PR DESCRIPTION
This is related to [this discussion](https://github.com/ipa320/cob_common/pull/175#issuecomment-154128294) from https://github.com/ipa320/cob_common/pull/175

By adding the sensors like this, the original sensorring.urdf.xacro in cob_common (i.e. without sensor) can be used without any changes in cob_common (i.e. the sensorring_XXX.urdf.xacro could be removed again). In case another/additional sensor is mounted to the sensorring (or anywhere else on the robot), only the new file `cob4-2.sensors.xacro` needs to be modified (and of course according launch files in cob4-2.xml).

I'm open for discussion about how to name this file....maybe it could make sense to name it (non-sensor-related) e.g. cob4-2.[additons|aux|...].xacro. If we name it in a more general way, it might not necessarily be limited to sensors...but could be used for other components, too...
Doing it like that could also be applied to the other robots...i.e. raw3-1 has a lot of "attachements" added within raw3-1.urdf.xacro....by moving those into the additional file...the main file would look "cleaner"...

What do you think?
Agreement could be discussed on Monday!
