### PR TITLE
[hotfix] remove head and arms from teleop config

### DIFF
--- a/cob_hardware_config/cob4-1/config/teleop.yaml
+++ b/cob_hardware_config/cob4-1/config/teleop.yaml
@@ -69,30 +69,9 @@ components: {
     twist_topic_name: '/torso/twist_controller/command_twist',
     twist_max_velocity: [0.3, 0.2, 0.3, 0.3, 0.2, 0.3]
   },
-  head: {
-    sss_default_target: "front",
-    velocity_topic_name: "/head/joint_group_velocity_controller/command",
-    joint_velocity: [0.05, 0.05],
-    twist_topic_name: '/head/twist_controller/command_twist',
-    twist_max_velocity: [0.3, 0.2, 0.3, 0.3, 0.2, 0.3]
-  },
   sensorring: {
     sss_default_target: "front",
     velocity_topic_name: "/sensorring/joint_group_velocity_controller/command",
     joint_velocity: [0.05]
-  },
-  arm_left: {
-    sss_default_target: "folded",
-    velocity_topic_name: "/arm_left/joint_group_velocity_controller/command",
-    joint_velocity: [0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05],
-    twist_topic_name: '/arm_left/twist_controller/command_twist',
-    twist_max_velocity: [0.3, 0.2, 0.3, 0.3, 0.2, 0.3]
-  },
-  arm_right: {
-    sss_default_target: "folded",
-    velocity_topic_name: "/arm_right/joint_group_velocity_controller/command",
-    joint_velocity: [0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05],
-    twist_topic_name: '/arm_right/twist_controller/command_twist',
-    twist_max_velocity: [0.3, 0.2, 0.3, 0.3, 0.2, 0.3]
   }
 }


### PR DESCRIPTION
cob4-1 currently has no arms and no head. This hotfix is needed to init and recover by joystick.
