### PR TITLE
remove env config in all robot launch files

### DIFF
--- a/cob_bringup/robot.launch
+++ b/cob_bringup/robot.launch
@@ -3,12 +3,7 @@
 
 	<param name="/use_sim_time" value="false"/>
 	<arg name="robot" default="$(optenv ROBOT !!NO_ROBOT_SET!!)"/>
-	<arg name="robot_env" default="$(optenv ROBOT_ENV !!NO_ROBOT_ENV_SET!!)"/>
-	<arg name="pkg_env_config" default="$(find cob_default_env_config)"/>
 
-	<include file="$(find cob_bringup)/robots/$(arg robot).launch" >
-		<arg name="robot_env" value="$(arg robot_env)" />
-		<arg name="pkg_env_config" value="$(arg pkg_env_config)" />
-	</include>
+	<include file="$(find cob_bringup)/robots/$(arg robot).launch"/>
 
 </launch>

--- a/cob_bringup/robots/cob3-2.launch
+++ b/cob_bringup/robots/cob3-2.launch
@@ -1,18 +1,10 @@
 <?xml version="1.0"?>
 <launch>
 
-	<arg name="robot_env" default="$(optenv ROBOT_ENV !!NO_ROBOT_ENV_SET!!)"/>
-	<arg name="pkg_env_config" default="$(find cob_default_env_config)"/>
-
 	<include file="$(find cob_bringup)/robots/cob3-2.xml" >
 		<arg name="pc1" value="cob3-2-pc1"/>
 		<arg name="pc2" value="cob3-2-pc2"/>
 		<arg name="pc3" value="cob3-2-pc3"/>
-	</include>
-
-	<!-- upload default configuration parameters -->
-	<include file="$(arg pkg_env_config)/upload_navigation_goals.launch">
-		<arg name="robot_env" value="$(arg robot_env)" />
 	</include>
 
 </launch>

--- a/cob_bringup/robots/cob3-6.launch
+++ b/cob_bringup/robots/cob3-6.launch
@@ -1,17 +1,9 @@
 <?xml version="1.0"?>
 <launch>
 
-	<arg name="robot_env" default="$(optenv ROBOT_ENV !!NO_ROBOT_ENV_SET!!)"/>
-	<arg name="pkg_env_config" default="$(find cob_default_env_config)"/>
-
 	<include file="$(find cob_bringup)/robots/cob3-6.xml" >
 		<arg name="pc1" value="cob3-6-pc1"/>
 		<arg name="pc2" value="cob3-6-pc2"/>
-	</include>
-
-	<!-- upload default configuration parameters -->
-	<include file="$(arg pkg_env_config)/upload_navigation_goals.launch">
-		<arg name="robot_env" value="$(arg robot_env)" />
 	</include>
 
 </launch>

--- a/cob_bringup/robots/cob3-9.launch
+++ b/cob_bringup/robots/cob3-9.launch
@@ -1,18 +1,10 @@
 <?xml version="1.0"?>
 <launch>
 
-	<arg name="robot_env" default="$(optenv ROBOT_ENV !!NO_ROBOT_ENV_SET!!)"/>
-	<arg name="pkg_env_config" default="$(find cob_default_env_config)"/>
-
 	<include file="$(find cob_bringup)/robots/cob3-9.xml" >
 		<arg name="pc1" value="cob3-9-pc1"/>
 		<arg name="pc2" value="cob3-9-pc2"/>
 		<arg name="pc3" value="cob3-9-pc3"/>
-	</include>
-
-	<!-- upload default configuration parameters -->
-	<include file="$(arg pkg_env_config)/upload_navigation_goals.launch">
-		<arg name="robot_env" value="$(arg robot_env)" />
 	</include>
 
 </launch>

--- a/cob_bringup/robots/cob4-1.launch
+++ b/cob_bringup/robots/cob4-1.launch
@@ -1,9 +1,6 @@
 <?xml version="1.0"?>
 <launch>
 
-	<arg name="robot_env" default="$(optenv ROBOT_ENV !!NO_ROBOT_ENV_SET!!)"/>
-	<arg name="pkg_env_config" default="$(find cob_default_env_config)"/>
-
 	<include file="$(find cob_bringup)/robots/cob4-1.xml" >
 		<arg name="cob4-1-b1" value="cob4-2-b1"/>
 		<arg name="cob4-1-t1" value="cob4-2-t1"/>
@@ -12,10 +9,5 @@
 		<arg name="cob4-1-s1" value="cob4-2-s1"/>
 		<arg name="cob4-1-h1" value="cob4-2-h1"/>
 	</include>
-
-	<!-- upload default configuration parameters -->
-	<!--include file="$(arg pkg_env_config)/upload_navigation_goals.launch">
-		<arg name="robot_env" value="$(arg robot_env)" />
-	</include-->
 
 </launch>

--- a/cob_bringup/robots/cob4-2.launch
+++ b/cob_bringup/robots/cob4-2.launch
@@ -1,9 +1,6 @@
 <?xml version="1.0"?>
 <launch>
 
-	<arg name="robot_env" default="$(optenv ROBOT_ENV !!NO_ROBOT_ENV_SET!!)"/>
-	<arg name="pkg_env_config" default="$(find cob_default_env_config)"/>
-
 	<include file="$(find cob_bringup)/robots/cob4-2.xml" >
 		<arg name="cob4-2-b1" value="cob4-2-b1"/>
 		<arg name="cob4-2-t1" value="cob4-2-t1"/>
@@ -12,10 +9,5 @@
 		<arg name="cob4-2-s1" value="cob4-2-s1"/>
 		<arg name="cob4-2-h1" value="cob4-2-h1"/>
 	</include>
-
-	<!-- upload default configuration parameters -->
-	<!--include file="$(arg pkg_env_config)/upload_navigation_goals.launch">
-		<arg name="robot_env" value="$(arg robot_env)" />
-	</include-->
 
 </launch>

--- a/cob_bringup/robots/cob4-3.launch
+++ b/cob_bringup/robots/cob4-3.launch
@@ -1,9 +1,6 @@
 <?xml version="1.0"?>
 <launch>
 
-	<arg name="robot_env" default="$(optenv ROBOT_ENV !!NO_ROBOT_ENV_SET!!)"/>
-	<arg name="pkg_env_config" default="$(find cob_default_env_config)"/>
-
 	<include file="$(find cob_bringup)/robots/cob4-3.xml" >
 		<arg name="cob4-3-b1" value="cob4-3-b1"/>
 	</include>

--- a/cob_bringup/robots/cob4-4.launch
+++ b/cob_bringup/robots/cob4-4.launch
@@ -1,9 +1,6 @@
 <?xml version="1.0"?>
 <launch>
 
-	<arg name="robot_env" default="$(optenv ROBOT_ENV !!NO_ROBOT_ENV_SET!!)"/>
-	<arg name="pkg_env_config" default="$(find cob_default_env_config)"/>
-
 	<include file="$(find cob_bringup)/robots/cob4-4.xml" >
 		<arg name="cob4-4-b1" value="cob4-4-b1"/>
 	</include>

--- a/cob_bringup/robots/cob4-6.launch
+++ b/cob_bringup/robots/cob4-6.launch
@@ -1,9 +1,6 @@
 <?xml version="1.0"?>
 <launch>
 
-	<arg name="robot_env" default="$(optenv ROBOT_ENV !!NO_ROBOT_ENV_SET!!)"/>
-	<arg name="pkg_env_config" default="$(find cob_default_env_config)"/>
-
 	<include file="$(find cob_bringup)/robots/cob4-6.xml" >
 		<arg name="cob4-6-b1" value="cob4-6-b1"/>
 	</include>

--- a/cob_bringup/robots/raw3-1.launch
+++ b/cob_bringup/robots/raw3-1.launch
@@ -1,19 +1,11 @@
 <?xml version="1.0"?>
 <launch>
 
-	<arg name="robot_env" default="$(optenv ROBOT_ENV !!NO_ROBOT_ENV_SET!!)"/>
-	<arg name="pkg_env_config" default="$(find cob_default_env_config)"/>
-
 	<include file="$(find cob_bringup)/robots/raw3-1.xml" >
 		<arg name="pc1" value="raw3-1-pc1"/>
 		<arg name="pc2" value="raw3-1-pc2"/>
 		<arg name="pc3" value="raw3-1-pc3"/>
 		<arg name="ur_ip" value="192.168.141.40"/>
-	</include>
-
-	<!-- upload default configuration parameters -->
-	<include file="$(arg pkg_env_config)/upload_navigation_goals.launch">
-		<arg name="robot_env" value="$(arg robot_env)" />
 	</include>
 
 </launch>

--- a/cob_bringup/robots/raw3-2.launch
+++ b/cob_bringup/robots/raw3-2.launch
@@ -1,16 +1,8 @@
 <?xml version="1.0"?>
 <launch>
 
-	<arg name="robot_env" default="$(optenv ROBOT_ENV !!NO_ROBOT_ENV_SET!!)"/>
-	<arg name="pkg_env_config" default="$(find cob_default_env_config)"/>
-
 	<include file="$(find cob_bringup)/robots/raw3-2.xml" >
 		<arg name="pc1" value="raw3-2-pc1"/>
-	</include>
-
-	<!-- upload default configuration parameters -->
-	<include file="$(arg pkg_env_config)/upload_navigation_goals.launch">
-		<arg name="robot_env" value="$(arg robot_env)" />
 	</include>
 
 </launch>

--- a/cob_bringup/robots/raw3-3.launch
+++ b/cob_bringup/robots/raw3-3.launch
@@ -1,18 +1,10 @@
 <?xml version="1.0"?>
 <launch>
 
-	<arg name="robot_env" default="$(optenv ROBOT_ENV !!NO_ROBOT_ENV_SET!!)"/>
-	<arg name="pkg_env_config" default="$(find cob_default_env_config)"/>
-
 	<include file="$(find cob_bringup)/robots/raw3-3.xml" >
 		<arg name="pc1" value="raw3-3-pc1"/>
 		<arg name="pc2" value="raw3-3-pc2"/>
 		<arg name="pc3" value="raw3-3-pc3"/>
-	</include>
-
-	<!-- upload default configuration parameters -->
-	<include file="$(arg pkg_env_config)/upload_navigation_goals.launch">
-		<arg name="robot_env" value="$(arg robot_env)" />
 	</include>
 
 </launch>

--- a/cob_bringup/robots/raw3-4.launch
+++ b/cob_bringup/robots/raw3-4.launch
@@ -1,19 +1,11 @@
 <?xml version="1.0"?>
 <launch>
 
-	<arg name="robot_env" default="$(optenv ROBOT_ENV !!NO_ROBOT_ENV_SET!!)"/>
-	<arg name="pkg_env_config" default="$(find cob_default_env_config)"/>
-
 	<include file="$(find cob_bringup)/robots/raw3-4.xml" >
 		<arg name="pc1" value="raw3-4-pc1"/>
 		<arg name="pc2" value="raw3-4-pc2"/>
 		<arg name="pc3" value="raw3-4-pc3"/>
 		<arg name="ur_ip" value="192.168.44.51"/>
-	</include>
-
-	<!-- upload default configuration parameters -->
-	<include file="$(arg pkg_env_config)/upload_navigation_goals.launch">
-		<arg name="robot_env" value="$(arg robot_env)" />
 	</include>
 
 </launch>

--- a/cob_bringup/robots/raw3-5.launch
+++ b/cob_bringup/robots/raw3-5.launch
@@ -1,16 +1,8 @@
 <?xml version="1.0"?>
 <launch>
 
-	<arg name="robot_env" default="$(optenv ROBOT_ENV !!NO_ROBOT_ENV_SET!!)"/>
-	<arg name="pkg_env_config" default="$(find cob_default_env_config)"/>
-
 	<include file="$(find cob_bringup)/robots/raw3-5.xml" >
 		<arg name="pc1" value="i60sr2"/>
-	</include>
-
-	<!-- upload default configuration parameters -->
-	<include file="$(arg pkg_env_config)/upload_navigation_goals.launch">
-		<arg name="robot_env" value="$(arg robot_env)" />
 	</include>
 
 </launch>

--- a/cob_bringup/robots/raw3-6.launch
+++ b/cob_bringup/robots/raw3-6.launch
@@ -1,17 +1,8 @@
 <?xml version="1.0"?>
 <launch>
 
-	<arg name="robot_env" default="$(optenv ROBOT_ENV !!NO_ROBOT_ENV_SET!!)"/>
-	<arg name="pkg_env_config" default="$(find cob_default_env_config)"/>
-
 	<include file="$(find cob_bringup)/robots/raw3-6.xml" >
 		<arg name="pc1" value="raw3-6-pc1"/>
 	</include>
-
-	<!-- upload default configuration parameters -->
-	<include file="$(arg pkg_env_config)/upload_navigation_goals.launch">
-		<arg name="robot_env" value="$(arg robot_env)" />
-	</include>
-
 
 </launch>

--- a/cob_bringup/tools/android.launch
+++ b/cob_bringup/tools/android.launch
@@ -3,7 +3,6 @@
 
 	<arg name="robot" default="$(optenv ROBOT !!NO_ROBOT_SET!!)"/>
 	<arg name="pkg_robot_config" default="$(find cob_default_robot_config)"/>
-	<arg name="pkg_env_config" default="$(find cob_default_env_config)"/>
 
 	<node pkg="cob_android_script_server" type="script_server_android" name="android_script_server" cwd="node" respawn="false" output="screen" >
 		<rosparam command="load" ns="control_buttons" file="$(arg pkg_robot_config)/$(arg robot)/command_gui_buttons.yaml"/>


### PR DESCRIPTION
we do not want a dependency to env config for the robot launch files, thus removing.
Navigation goals need to be uploaded separately (e.g. in scenario.launch, but not in robot bringup)

fixes #373 
