### PR TITLE
use phidgets rather than simulated relayboard on raw3-1

### DIFF
--- a/cob_bringup/robots/raw3-1.xml
+++ b/cob_bringup/robots/raw3-1.xml
@@ -41,8 +41,8 @@
 			<arg name="robot" value="$(arg robot)" />
 			<arg name="name" value="base_laser_rear" />
 		</include>
-		<include file="$(find cob_bringup)/drivers/relayboard.launch" >
-			<arg name="sim" value="true" />
+		<include file="$(find cob_bringup)/drivers/phidgets.launch" >
+			<arg name="robot" value="$(arg robot)" />
 		</include>
 		<include file="$(find cob_bringup)/drivers/battery_voltage_filter.launch" >
 			<arg name="robot" value="$(arg robot)" />

--- a/cob_hardware_config/raw3-1/config/phidgets.yaml
+++ b/cob_hardware_config/raw3-1/config/phidgets.yaml
@@ -1,0 +1,25 @@
+frequency: 30                       #nodes update frequency in hz
+update_mode: polling                #switch between poll and event driven processing [polling, event]
+
+boards:
+  ifk_general:
+    serial_num: 285651
+    ratiometric: true
+    sensors:
+      bat1:
+        type: analog
+        index: 0
+      bat2:
+        type: analog
+        index: 1
+      em_stop_laser_rear:
+        type: digital_in
+        index: 6
+      em_stop_laser_front:
+        type: digital_in
+        index: 7
+      example1:
+        type: analog
+        index: 4
+        change_trigger: 10          #the sensors change trigger value (only event driven mode)
+        data_rate: 20               #ports data rate

--- a/cob_hardware_config/raw3-1/config/phidgets.yaml
+++ b/cob_hardware_config/raw3-1/config/phidgets.yaml
@@ -6,10 +6,10 @@ boards:
     serial_num: 285651
     ratiometric: true
     sensors:
-      bat1:
+      voltage:
         type: analog
         index: 0
-      bat2:
+      current:
         type: analog
         index: 1
       em_stop_laser_rear:


### PR DESCRIPTION
(supposed to) fix #403 

This is just a copy of the raw3-3 configuration and needs to be adjusted and tested on raw3-1
@ipa-bnm can you help me here?
