### PR TITLE
set lock priority for twist mux

### DIFF
--- a/cob_hardware_config/common/twist_mux_locks.yaml
+++ b/cob_hardware_config/common/twist_mux_locks.yaml
@@ -19,4 +19,4 @@ locks:
   name    : joystick 
   topic   : twist_mux/locks/joy_priority
   timeout : 0.0
-  priority: 100
+  priority: 101

--- a/cob_hardware_config/common/twist_mux_locks.yaml
+++ b/cob_hardware_config/common/twist_mux_locks.yaml
@@ -15,8 +15,8 @@ locks:
   timeout : 0.0
   priority: 21
 -
-  name    : pause_joystick 
-  topic   : twist_mux/locks/pause_joystick
+  name    : pause_teleop 
+  topic   : twist_mux/locks/pause_teleop
   timeout : 0.0
   priority: 101
 -

--- a/cob_hardware_config/common/twist_mux_locks.yaml
+++ b/cob_hardware_config/common/twist_mux_locks.yaml
@@ -10,13 +10,17 @@
 
 locks:
 -
-  name    : pause
+  name    : pause_navigation
   topic   : twist_mux/locks/pause_navigation
   timeout : 0.0
-  # Lower/same priority as joystick control, so it'll not block it.
-  priority: 80
+  priority: 21
 -
-  name    : joystick 
-  topic   : twist_mux/locks/joy_priority
+  name    : pause_joystick 
+  topic   : twist_mux/locks/pause_joystick
   timeout : 0.0
   priority: 101
+-
+  name    : pause_all 
+  topic   : twist_mux/locks/pause_all
+  timeout : 0.0
+  priority: 255


### PR DESCRIPTION
should be higher than normal joystick priority (is 100)
