### PR TITLE
restructure canopen driver yamls and remove canX yamls

### DIFF
--- a/cob_bringup/drivers/canopen_402.launch
+++ b/cob_bringup/drivers/canopen_402.launch
@@ -8,7 +8,7 @@
 
 	<!-- parameters for CANopen node -->
 	<node ns="$(arg component_name)" pkg="canopen_motor_node" type="canopen_motor_node" name="$(arg component_name)_driver" output="screen" clear_params="true">
-		<rosparam command="load" file="$(arg pkg_hardware_config)/$(arg robot)/config/$(arg can_device).yaml" />
+		<rosparam param="bus/device" subst_value="True">$(arg can_device)</rosparam>
 		<rosparam command="load" file="$(arg pkg_hardware_config)/$(arg robot)/config/$(arg component_name)_driver.yaml" />
 	</node>
 

--- a/cob_hardware_config/cob3-6/config/can1.yaml
+++ b/cob_hardware_config/cob3-6/config/can1.yaml
@@ -1,5 +1,0 @@
-bus:
-  device: can1
-sync:
-  interval_ms: 10
-  overflow: 0

--- a/cob_hardware_config/cob3-6/config/can2.yaml
+++ b/cob_hardware_config/cob3-6/config/can2.yaml
@@ -1,5 +1,0 @@
-bus:
-  device: can2
-sync:
-  interval_ms: 10
-  overflow: 0

--- a/cob_hardware_config/cob3-9/config/arm_driver.yaml
+++ b/cob_hardware_config/cob3-9/config/arm_driver.yaml
@@ -1,4 +1,6 @@
-name: arm_controller
+sync:
+  interval_ms: 10
+  overflow: 0
 
 defaults:
   eds_pkg: cob_hardware_config

--- a/cob_hardware_config/cob3-9/config/can0.yaml
+++ b/cob_hardware_config/cob3-9/config/can0.yaml
@@ -1,5 +1,0 @@
-bus:
-  device: can0
-sync:
-  interval_ms: 10
-  overflow: 0

--- a/cob_hardware_config/cob3-9/config/can1.yaml
+++ b/cob_hardware_config/cob3-9/config/can1.yaml
@@ -1,5 +1,0 @@
-bus:
-  device: can1
-sync:
-  interval_ms: 10
-  overflow: 0

--- a/cob_hardware_config/cob3-9/config/can2.yaml
+++ b/cob_hardware_config/cob3-9/config/can2.yaml
@@ -1,5 +1,0 @@
-bus:
-  device: can2
-sync:
-  interval_ms: 10
-  overflow: 0

--- a/cob_hardware_config/cob3-9/config/can3.yaml
+++ b/cob_hardware_config/cob3-9/config/can3.yaml
@@ -1,5 +1,0 @@
-bus:
-  device: can3
-sync:
-  interval_ms: 10
-  overflow: 0

--- a/cob_hardware_config/cob3-9/config/gripper_driver.yaml
+++ b/cob_hardware_config/cob3-9/config/gripper_driver.yaml
@@ -1,4 +1,6 @@
-name: gripper_controller
+sync:
+  interval_ms: 10
+  overflow: 0
 
 defaults:
   eds_pkg: cob_hardware_config

--- a/cob_hardware_config/cob3-9/config/torso_driver.yaml
+++ b/cob_hardware_config/cob3-9/config/torso_driver.yaml
@@ -1,4 +1,6 @@
-name: torso_controller
+sync:
+  interval_ms: 10
+  overflow: 0
 
 defaults:
   eds_pkg: cob_hardware_config

--- a/cob_hardware_config/cob3-9/config/tray_driver.yaml
+++ b/cob_hardware_config/cob3-9/config/tray_driver.yaml
@@ -1,4 +1,6 @@
-name: tray_controller
+sync:
+  interval_ms: 10
+  overflow: 0
 
 defaults:
   eds_pkg: cob_hardware_config

--- a/cob_hardware_config/cob4-1/config/can0.yaml
+++ b/cob_hardware_config/cob4-1/config/can0.yaml
@@ -1,1 +1,0 @@
-../../cob4-2/config/can0.yaml

--- a/cob_hardware_config/cob4-1/config/can1.yaml
+++ b/cob_hardware_config/cob4-1/config/can1.yaml
@@ -1,1 +1,0 @@
-../../cob4-2/config/can1.yaml

--- a/cob_hardware_config/cob4-1/config/can2.yaml
+++ b/cob_hardware_config/cob4-1/config/can2.yaml
@@ -1,1 +1,0 @@
-../../cob4-2/config/can2.yaml

--- a/cob_hardware_config/cob4-1/config/can3.yaml
+++ b/cob_hardware_config/cob4-1/config/can3.yaml
@@ -1,1 +1,0 @@
-../../cob4-2/config/can3.yaml

--- a/cob_hardware_config/cob4-2/config/arm_left_driver.yaml
+++ b/cob_hardware_config/cob4-2/config/arm_left_driver.yaml
@@ -1,4 +1,6 @@
-name: arm_left_controller
+sync:
+  interval_ms: 10
+  overflow: 0
 
 defaults:
   eds_pkg: cob_hardware_config

--- a/cob_hardware_config/cob4-2/config/arm_right_driver.yaml
+++ b/cob_hardware_config/cob4-2/config/arm_right_driver.yaml
@@ -1,4 +1,6 @@
-name: arm_right_controller
+sync:
+  interval_ms: 10
+  overflow: 0
 
 defaults:
   eds_pkg: cob_hardware_config

--- a/cob_hardware_config/cob4-2/config/base_driver.yaml
+++ b/cob_hardware_config/cob4-2/config/base_driver.yaml
@@ -1,3 +1,10 @@
+sync:
+  interval_ms: 10
+  overflow: 0
+heartbeat:
+  rate: 20
+  msg: "77f#05"
+
 defaults:
   eds_pkg: cob_hardware_config
   eds_file: "common/ElmoSimplIQ.dcf"

--- a/cob_hardware_config/cob4-2/config/can0.yaml
+++ b/cob_hardware_config/cob4-2/config/can0.yaml
@@ -1,9 +1,0 @@
-bus:
-  device: can0
-  master_allocator: canopen::SimpleMaster::Allocator
-sync:
-  interval_ms: 10
-  overflow: 0
-heartbeat:
-  rate: 20
-  msg: "77f#05"

--- a/cob_hardware_config/cob4-2/config/can1.yaml
+++ b/cob_hardware_config/cob4-2/config/can1.yaml
@@ -1,6 +1,0 @@
-bus:
-  device: can1
-sync:
-  interval_ms: 10
-  overflow: 0
-  silence_us: 250

--- a/cob_hardware_config/cob4-2/config/can2.yaml
+++ b/cob_hardware_config/cob4-2/config/can2.yaml
@@ -1,5 +1,0 @@
-bus:
-  device: can2
-sync:
-  interval_ms: 10
-  overflow: 0

--- a/cob_hardware_config/cob4-2/config/can3.yaml
+++ b/cob_hardware_config/cob4-2/config/can3.yaml
@@ -1,5 +1,0 @@
-bus:
-  device: can3
-sync:
-  interval_ms: 10
-  overflow: 0

--- a/cob_hardware_config/cob4-2/config/sensorring_driver.yaml
+++ b/cob_hardware_config/cob4-2/config/sensorring_driver.yaml
@@ -1,4 +1,9 @@
-name: sensorring_controller
+sync:
+  interval_ms: 10
+  overflow: 0
+heartbeat:
+  rate: 20
+  msg: "77f#05"
 
 defaults:
   eds_pkg: cob_hardware_config

--- a/cob_hardware_config/cob4-2/config/torso_driver.yaml
+++ b/cob_hardware_config/cob4-2/config/torso_driver.yaml
@@ -1,3 +1,10 @@
+sync:
+  interval_ms: 10
+  overflow: 0
+heartbeat:
+  rate: 20
+  msg: "77f#05"
+
 defaults:
   eds_pkg: cob_hardware_config
   eds_file: "common/Elmo.dcf"

--- a/cob_hardware_config/cob4-3/config/base_driver.yaml
+++ b/cob_hardware_config/cob4-3/config/base_driver.yaml
@@ -1,3 +1,10 @@
+sync:
+  interval_ms: 20
+  overflow: 0
+heartbeat:
+  rate: 20
+  msg: "77f#05"
+
 defaults:
   eds_pkg: cob_hardware_config
   eds_file: "cob4-3/config/Elmo.dcf"

--- a/cob_hardware_config/cob4-3/config/can0.yaml
+++ b/cob_hardware_config/cob4-3/config/can0.yaml
@@ -1,9 +1,0 @@
-bus:
-  device: can0
-  master_allocator: canopen::SimpleMaster::Allocator
-sync:
-  interval_ms: 20
-  overflow: 0
-heartbeat:
-  rate: 20
-  msg: "77f#05"

--- a/cob_hardware_config/cob4-4/config/base_driver.yaml
+++ b/cob_hardware_config/cob4-4/config/base_driver.yaml
@@ -1,3 +1,10 @@
+sync:
+  interval_ms: 20
+  overflow: 0
+heartbeat:
+  rate: 20
+  msg: "77f#05"
+
 defaults:
   eds_pkg: cob_hardware_config
   eds_file: "cob4-4/config/Elmo.dcf"

--- a/cob_hardware_config/cob4-4/config/can0.yaml
+++ b/cob_hardware_config/cob4-4/config/can0.yaml
@@ -1,9 +1,0 @@
-bus:
-  device: can0
-  master_allocator: canopen::SimpleMaster::Allocator
-sync:
-  interval_ms: 20
-  overflow: 0
-heartbeat:
-  rate: 20
-  msg: "77f#05"

--- a/cob_hardware_config/cob4-6/config/base_driver.yaml
+++ b/cob_hardware_config/cob4-6/config/base_driver.yaml
@@ -1,3 +1,10 @@
+sync:
+  interval_ms: 20
+  overflow: 0
+heartbeat:
+  rate: 20
+  msg: "77f#05"
+
 defaults:
   eds_pkg: cob_hardware_config
   eds_file: "cob4-6/config/Elmo.dcf"

--- a/cob_hardware_config/cob4-6/config/can0.yaml
+++ b/cob_hardware_config/cob4-6/config/can0.yaml
@@ -1,9 +1,0 @@
-bus:
-  device: can0
-  master_allocator: canopen::SimpleMaster::Allocator
-sync:
-  interval_ms: 20
-  overflow: 0
-heartbeat:
-  rate: 20
-  msg: "77f#05"


### PR DESCRIPTION
fixes #420 according to @ipa-mdl's concept

I did not adjust the driver.yaml's of:
- raw3-3
- raw3-6
  as they still use the old ipa_canopen config layout in there respective yaml file and we do not have access to the hardware....
