### PR TITLE
rename canopen node and adjust diagnostics

### DIFF
--- a/cob_bringup/drivers/canopen_402.launch
+++ b/cob_bringup/drivers/canopen_402.launch
@@ -7,7 +7,7 @@
 	<arg name="can_device"/>
 
 	<!-- parameters for CANopen node -->
-	<node ns="$(arg component_name)" pkg="canopen_motor_node" type="canopen_motor_node" name="$(arg component_name)_driver" output="screen" clear_params="true">
+	<node ns="$(arg component_name)" pkg="canopen_motor_node" type="canopen_motor_node" name="driver" output="screen" clear_params="true">
 		<rosparam command="load" file="$(arg pkg_hardware_config)/$(arg robot)/config/$(arg can_device).yaml" />
 		<rosparam command="load" file="$(arg pkg_hardware_config)/$(arg robot)/config/$(arg component_name)_driver.yaml" />
 	</node>

--- a/cob_hardware_config/cob3-6/config/diagnostics_analyzers.yaml
+++ b/cob_hardware_config/cob3-6/config/diagnostics_analyzers.yaml
@@ -72,11 +72,11 @@ analyzers:
       torso:
         type: diagnostic_aggregator/GenericAnalyzer
         path: Torso
-        contains: 'torso'
+        contains: 'torso/driver'
       tray:
         type: diagnostic_aggregator/GenericAnalyzer
         path: Tray
-        contains: 'tray'
+        contains: 'tray/driver'
       gripper:
         type: diagnostic_aggregator/GenericAnalyzer
         path: Gripper

--- a/cob_hardware_config/cob3-9/config/diagnostics_analyzers.yaml
+++ b/cob_hardware_config/cob3-9/config/diagnostics_analyzers.yaml
@@ -78,15 +78,15 @@ analyzers:
       torso:
         type: diagnostic_aggregator/GenericAnalyzer
         path: Torso
-        contains: 'torso'
+        contains: 'torso/driver'
       tray:
         type: diagnostic_aggregator/GenericAnalyzer
         path: Tray
-        contains: 'tray'
+        contains: 'tray/driver'
       gripper:
         type: diagnostic_aggregator/GenericAnalyzer
         path: Gripper
-        contains: 'gripper'
+        contains: 'gripper/driver'
       head:
         type: diagnostic_aggregator/GenericAnalyzer
         path: Head
@@ -94,7 +94,7 @@ analyzers:
       arm:
         type: diagnostic_aggregator/GenericAnalyzer
         path: LWA
-        contains: 'arm'
+        contains: 'arm/driver'
       base:
         type: diagnostic_aggregator/AnalyzerGroup
         path: Base

--- a/cob_hardware_config/cob4-1/config/diagnostics_analyzers.yaml
+++ b/cob_hardware_config/cob4-1/config/diagnostics_analyzers.yaml
@@ -80,15 +80,15 @@ analyzers:
       torso:
         type: diagnostic_aggregator/GenericAnalyzer
         path: Torso
-        contains: 'torso_driver'
+        contains: 'torso/driver'
 #      head:
 #        type: diagnostic_aggregator/GenericAnalyzer
 #        path: Head
-#        contains: 'head_driver'
+#        contains: 'head/driver'
       sensorring:
         type: diagnostic_aggregator/GenericAnalyzer
         path: Sensorring
-        contains: 'sensorring_driver'
+        contains: 'sensorring/driver'
       base:
         type: diagnostic_aggregator/AnalyzerGroup
         path: Base
@@ -96,7 +96,7 @@ analyzers:
           base:
             type: diagnostic_aggregator/GenericAnalyzer
             path: drives
-            contains: 'base_driver'
+            contains: 'base/driver'
           base_twist_mux:
             type: diagnostic_aggregator/GenericAnalyzer
             path: twist_mux

--- a/cob_hardware_config/cob4-2/config/diagnostics_analyzers.yaml
+++ b/cob_hardware_config/cob4-2/config/diagnostics_analyzers.yaml
@@ -80,19 +80,19 @@ analyzers:
       torso:
         type: diagnostic_aggregator/GenericAnalyzer
         path: Torso
-        contains: 'torso_driver'
+        contains: 'torso/driver'
       sensorring:
         type: diagnostic_aggregator/GenericAnalyzer
         path: Sensorring
-        contains: 'sensorring_driver'
+        contains: 'sensorring/driver'
       arm_right:
         type: diagnostic_aggregator/GenericAnalyzer
         path: Arm Right
-        contains: 'arm_right_driver'
+        contains: 'arm_right/driver'
       arm_left:
         type: diagnostic_aggregator/GenericAnalyzer
         path: Arm Left
-        contains: 'arm_left_driver'
+        contains: 'arm_left/driver'
       base:
         type: diagnostic_aggregator/AnalyzerGroup
         path: Base
@@ -100,7 +100,7 @@ analyzers:
           base:
             type: diagnostic_aggregator/GenericAnalyzer
             path: drives
-            contains: 'base_driver'
+            contains: 'base/driver'
           base_twist_mux:
             type: diagnostic_aggregator/GenericAnalyzer
             path: twist_mux

--- a/cob_hardware_config/cob4-3/config/diagnostics_analyzers.yaml
+++ b/cob_hardware_config/cob4-3/config/diagnostics_analyzers.yaml
@@ -57,7 +57,7 @@ analyzers:
           base:
             type: diagnostic_aggregator/GenericAnalyzer
             path: drives
-            startswith: '/base'
+            startswith: 'base/driver'
           base_twist_mux:
             type: diagnostic_aggregator/GenericAnalyzer
             path: twist_mux

--- a/cob_hardware_config/cob4-4/config/diagnostics_analyzers.yaml
+++ b/cob_hardware_config/cob4-4/config/diagnostics_analyzers.yaml
@@ -57,7 +57,7 @@ analyzers:
           base:
             type: diagnostic_aggregator/GenericAnalyzer
             path: drives
-            startswith: '/base'
+            startswith: 'base/driver'
           base_twist_mux:
             type: diagnostic_aggregator/GenericAnalyzer
             path: twist_mux

--- a/cob_hardware_config/cob4-6/config/diagnostics_analyzers.yaml
+++ b/cob_hardware_config/cob4-6/config/diagnostics_analyzers.yaml
@@ -57,7 +57,7 @@ analyzers:
           base:
             type: diagnostic_aggregator/GenericAnalyzer
             path: drives
-            startswith: '/base'
+            startswith: 'base/driver'
           base_twist_mux:
             type: diagnostic_aggregator/GenericAnalyzer
             path: twist_mux


### PR DESCRIPTION
as discussed with @ipa-mdl - follow-up of #434 
- renamed the node name
- updated `contains` tags of the canopen components in diagnostic_analyzer for robots using canopen components
