### PR TITLE
setting default parameters for backwards compatibility with configurable odometry_controller

### DIFF
--- a/cob_hardware_config/cob3-2/config/base_controller.yaml
+++ b/cob_hardware_config/cob3-2/config/base_controller.yaml
@@ -37,6 +37,10 @@ twist_controller:
 odometry_controller:
   type: cob_omni_drive_controller/OdometryController
   publish_rate: 50
+  frame_id: "/odom_combined"
+  child_frame_id: "/base_footprint"
+  cov_pose: 0.1
+  cov_twist: 0.1
   defaults: # default settings for all wheels, can per overwritten per wheel
     wheel_radius: 0.080 # Radius of the wheels in [m]
   wheels: *wheels

--- a/cob_hardware_config/cob3-6/config/base_controller.yaml
+++ b/cob_hardware_config/cob3-6/config/base_controller.yaml
@@ -37,6 +37,10 @@ twist_controller:
 odometry_controller:
   type: cob_omni_drive_controller/OdometryController
   publish_rate: 50
+  frame_id: "/odom_combined"
+  child_frame_id: "/base_footprint"
+  cov_pose: 0.1
+  cov_twist: 0.1
   defaults: # default settings for all wheels, can per overwritten per wheel
     wheel_radius: 0.080 # Radius of the wheels in [m]
   wheels: *wheels

--- a/cob_hardware_config/cob3-9/config/base_controller.yaml
+++ b/cob_hardware_config/cob3-9/config/base_controller.yaml
@@ -37,6 +37,10 @@ twist_controller:
 odometry_controller:
   type: cob_omni_drive_controller/OdometryController
   publish_rate: 50
+  frame_id: "/odom_combined"
+  child_frame_id: "/base_footprint"
+  cov_pose: 0.1
+  cov_twist: 0.1
   defaults: # default settings for all wheels, can per overwritten per wheel
     wheel_radius: 0.080 # Radius of the wheels in [m]
   wheels: *wheels

--- a/cob_hardware_config/cob4-2/config/base_controller.yaml
+++ b/cob_hardware_config/cob4-2/config/base_controller.yaml
@@ -35,6 +35,10 @@ twist_controller:
 odometry_controller:
   type: cob_omni_drive_controller/OdometryController
   publish_rate: 50
+  frame_id: "/odom_combined"
+  child_frame_id: "/base_footprint"
+  cov_pose: 0.1
+  cov_twist: 0.1
   wheels: *wheels
 
 joint_group_velocity_controller:

--- a/cob_hardware_config/cob4-3/config/base_controller.yaml
+++ b/cob_hardware_config/cob4-3/config/base_controller.yaml
@@ -34,4 +34,8 @@ twist_controller:
 odometry_controller:
   type: cob_omni_drive_controller/OdometryController
   publish_rate: 50
+  frame_id: "/odom_combined"
+  child_frame_id: "/base_footprint"
+  cov_pose: 0.1
+  cov_twist: 0.1
   wheels: *wheels

--- a/cob_hardware_config/cob4-4/config/base_controller.yaml
+++ b/cob_hardware_config/cob4-4/config/base_controller.yaml
@@ -34,4 +34,8 @@ twist_controller:
 odometry_controller:
   type: cob_omni_drive_controller/OdometryController
   publish_rate: 50
+  frame_id: "/odom_combined"
+  child_frame_id: "/base_footprint"
+  cov_pose: 0.1
+  cov_twist: 0.1
   wheels: *wheels

--- a/cob_hardware_config/cob4-6/config/base_controller.yaml
+++ b/cob_hardware_config/cob4-6/config/base_controller.yaml
@@ -34,4 +34,8 @@ twist_controller:
 odometry_controller:
   type: cob_omni_drive_controller/OdometryController
   publish_rate: 50
+  frame_id: "/odom_combined"
+  child_frame_id: "/base_footprint"
+  cov_pose: 0.1
+  cov_twist: 0.1
   wheels: *wheels

--- a/cob_hardware_config/raw3-1/config/base_controller.yaml
+++ b/cob_hardware_config/raw3-1/config/base_controller.yaml
@@ -37,6 +37,10 @@ twist_controller:
 odometry_controller:
   type: cob_omni_drive_controller/OdometryController
   publish_rate: 50
+  frame_id: "/odom_combined"
+  child_frame_id: "/base_footprint"
+  cov_pose: 0.1
+  cov_twist: 0.1
   defaults: # default settings for all wheels, can per overwritten per wheel
     wheel_radius: 0.080 # Radius of the wheels in [m]
   wheels: *wheels

--- a/cob_hardware_config/raw3-2/config/base_controller.yaml
+++ b/cob_hardware_config/raw3-2/config/base_controller.yaml
@@ -37,6 +37,10 @@ twist_controller:
 odometry_controller:
   type: cob_omni_drive_controller/OdometryController
   publish_rate: 50
+  frame_id: "/odom_combined"
+  child_frame_id: "/base_footprint"
+  cov_pose: 0.1
+  cov_twist: 0.1
   defaults: # default settings for all wheels, can per overwritten per wheel
     wheel_radius: 0.080 # Radius of the wheels in [m]
   wheels: *wheels

--- a/cob_hardware_config/raw3-3/config/base_controller.yaml
+++ b/cob_hardware_config/raw3-3/config/base_controller.yaml
@@ -37,6 +37,10 @@ twist_controller:
 odometry_controller:
   type: cob_omni_drive_controller/OdometryController
   publish_rate: 50
+  frame_id: "/odom_combined"
+  child_frame_id: "/base_footprint"
+  cov_pose: 0.1
+  cov_twist: 0.1
   defaults: # default settings for all wheels, can per overwritten per wheel
     wheel_radius: 0.080 # Radius of the wheels in [m]
   wheels: *wheels

--- a/cob_hardware_config/raw3-4/config/base_controller.yaml
+++ b/cob_hardware_config/raw3-4/config/base_controller.yaml
@@ -37,6 +37,10 @@ twist_controller:
 odometry_controller:
   type: cob_omni_drive_controller/OdometryController
   publish_rate: 50
+  frame_id: "/odom_combined"
+  child_frame_id: "/base_footprint"
+  cov_pose: 0.1
+  cov_twist: 0.1
   defaults: # default settings for all wheels, can per overwritten per wheel
     wheel_radius: 0.080 # Radius of the wheels in [m]
   wheels: *wheels

--- a/cob_hardware_config/raw3-5/config/base_controller.yaml
+++ b/cob_hardware_config/raw3-5/config/base_controller.yaml
@@ -37,6 +37,10 @@ twist_controller:
 odometry_controller:
   type: cob_omni_drive_controller/OdometryController
   publish_rate: 50
+  frame_id: "/odom_combined"
+  child_frame_id: "/base_footprint"
+  cov_pose: 0.1
+  cov_twist: 0.1
   defaults: # default settings for all wheels, can per overwritten per wheel
     wheel_radius: 0.080 # Radius of the wheels in [m]
   wheels: *wheels

--- a/cob_hardware_config/raw3-6/config/base_controller.yaml
+++ b/cob_hardware_config/raw3-6/config/base_controller.yaml
@@ -37,6 +37,10 @@ twist_controller:
 odometry_controller:
   type: cob_omni_drive_controller/OdometryController
   publish_rate: 50
+  frame_id: "/odom_combined"
+  child_frame_id: "/base_footprint"
+  cov_pose: 0.1
+  cov_twist: 0.1
   defaults: # default settings for all wheels, can per overwritten per wheel
     wheel_radius: 0.080 # Radius of the wheels in [m]
   wheels: *wheels


### PR DESCRIPTION
**only merge together with https://github.com/ipa320/cob_control/pull/90**

as the hardcoded default values of the odometry_controller have been changed in https://github.com/ipa320/cob_control/pull/90, this PR sets the according frames again in the yaml for backwards compatibility (until nav packages have been converted to new defaults).....this restores the behavior as it was before
