### PR TITLE
disable abortion checking as default

### DIFF
--- a/cob_hardware_config/cob4-2/config/torso_cartesian_controller.yaml
+++ b/cob_hardware_config/cob4-2/config/torso_cartesian_controller.yaml
@@ -72,7 +72,7 @@ frame_tracker:
   pid_rot_z: {p: 2.0, i: 0.0, d: 0.0, i_clamp: 0.0}
 
   # abortion criteria - cfg
-  enable_abortion_checking: true
+  enable_abortion_checking: false
   cart_min_dist_threshold_lin: 0.5
   cart_min_dist_threshold_rot: 0.1
   twist_dead_threshold_lin: 0.05


### PR DESCRIPTION
this allows to better use lookat and agile_driving
