### PR TITLE
enable velocity sensor for um2 mode

### DIFF
--- a/cob_hardware_config/cob4-2/config/base_driver.yaml
+++ b/cob_hardware_config/cob4-2/config/base_driver.yaml
@@ -1,5 +1,5 @@
 sync:
-  interval_ms: 10
+  interval_ms: 20
   overflow: 0
 heartbeat:
   rate: 20
@@ -9,6 +9,7 @@ defaults:
   eds_pkg: cob_hardware_config
   eds_file: "common/ElmoSimplIQ.dcf"
   dcf_overlay:
+    "606A": "1" # read velocity from velocity sensor
     "607F": "240000" # max profile velocity
     "6083": "1000000" # profile acceleration
     "6084": "1000000" # profile deceleration


### PR DESCRIPTION
fixes https://github.com/ipa320/cob_control/issues/98

includes #441 

currently only needed for cob4-1/cob4-2...not required for cob4-3/cob4-4/cob4-6...not yet applicable for cob3's and raw's (https://github.com/ipa320/cob_robots/issues/403)...
