### PR TITLE
remove joint_group_interpol_position_controller

### DIFF
--- a/cob_hardware_config/cob4-1/config/head_controller.yaml
+++ b/cob_hardware_config/cob4-1/config/head_controller.yaml
@@ -37,14 +37,6 @@ joint_group_position_controller:
      - head_3_joint
   required_drive_mode: 1
 
-joint_group_interpol_position_controller:
-  type: position_controllers/JointGroupPositionController
-  joints:
-     - head_1_joint
-     - head_2_joint
-     - head_3_joint
-  required_drive_mode: 7
-
 head_1_joint_position_controller:
   type: position_controllers/JointPositionController
   joint: head_1_joint
@@ -59,25 +51,24 @@ head_3_joint_position_controller:
   required_drive_mode: 1
 
 
-### velocity controller
-### velicty controllers are not to be used with Elmo Devices as JointLimits are not considered!
-#joint_group_velocity_controller:
-#  type: velocity_controllers/JointGroupVelocityController
-#  joints:
-#     - head_1_joint
-#     - head_2_joint
-#     - head_3_joint
-#  required_drive_mode: 3
-#
-#head_1_joint_velocity_controller:
-#  type: velocity_controllers/JointVelocityController
-#  joint: head_1_joint
-#  required_drive_mode: 3
-#head_2_joint_velocity_controller:
-#  type: velocity_controllers/JointVelocityController
-#  joint: head_2_joint
-#  required_drive_mode: 3
-#head_3_joint_velocity_controller:
-#  type: velocity_controllers/JointVelocityController
-#  joint: head_3_joint
-#  required_drive_mode: 3
+## velocity controller
+joint_group_velocity_controller:
+  type: velocity_controllers/JointGroupVelocityController
+  joints:
+     - head_1_joint
+     - head_2_joint
+     - head_3_joint
+  required_drive_mode: 3
+
+head_1_joint_velocity_controller:
+  type: velocity_controllers/JointVelocityController
+  joint: head_1_joint
+  required_drive_mode: 3
+head_2_joint_velocity_controller:
+  type: velocity_controllers/JointVelocityController
+  joint: head_2_joint
+  required_drive_mode: 3
+head_3_joint_velocity_controller:
+  type: velocity_controllers/JointVelocityController
+  joint: head_3_joint
+  required_drive_mode: 3

--- a/cob_hardware_config/cob4-2/config/arm_left_controller.yaml
+++ b/cob_hardware_config/cob4-2/config/arm_left_controller.yaml
@@ -49,18 +49,6 @@ joint_group_position_controller:
      - arm_left_7_joint
   required_drive_mode: 1
 
-joint_group_interpol_position_controller:
-  type: position_controllers/JointGroupPositionController
-  joints:
-     - arm_left_1_joint
-     - arm_left_2_joint
-     - arm_left_3_joint
-     - arm_left_4_joint
-     - arm_left_5_joint
-     - arm_left_6_joint
-     - arm_left_7_joint
-  required_drive_mode: 7
-
 arm_left_1_joint_position_controller:
   type: position_controllers/JointPositionController
   joint: arm_left_1_joint

--- a/cob_hardware_config/cob4-2/config/arm_right_controller.yaml
+++ b/cob_hardware_config/cob4-2/config/arm_right_controller.yaml
@@ -49,18 +49,6 @@ joint_group_position_controller:
      - arm_right_7_joint
   required_drive_mode: 1
 
-joint_group_interpol_position_controller:
-  type: position_controllers/JointGroupPositionController
-  joints:
-     - arm_right_1_joint
-     - arm_right_2_joint
-     - arm_right_3_joint
-     - arm_right_4_joint
-     - arm_right_5_joint
-     - arm_right_6_joint
-     - arm_right_7_joint
-  required_drive_mode: 7
-
 arm_right_1_joint_position_controller:
   type: position_controllers/JointPositionController
   joint: arm_right_1_joint

--- a/cob_hardware_config/cob4-2/config/torso_controller.yaml
+++ b/cob_hardware_config/cob4-2/config/torso_controller.yaml
@@ -34,13 +34,6 @@ joint_group_position_controller:
      - torso_3_joint
   required_drive_mode: 1
 
-joint_group_interpol_position_controller:
-  type: position_controllers/JointGroupPositionController
-  joints:
-     - torso_2_joint
-     - torso_3_joint
-  required_drive_mode: 7
-
 torso_2_joint_position_controller:
   type: position_controllers/JointPositionController
   joint: torso_2_joint
@@ -52,7 +45,6 @@ torso_3_joint_position_controller:
 
 
 ## velocity controller
-## velicty controllers are not to be used with Elmo Devices as JointLimits are not considered!
 joint_group_velocity_controller:
   type: velocity_controllers/JointGroupVelocityController
   joints:
@@ -60,11 +52,11 @@ joint_group_velocity_controller:
      - torso_3_joint
   required_drive_mode: 3
 
-#torso_2_joint_velocity_controller:
-#  type: velocity_controllers/JointVelocityController
-#  joint: torso_2_joint
-#  required_drive_mode: 3
-#torso_3_joint_velocity_controller:
-#  type: velocity_controllers/JointVelocityController
-#  joint: torso_3_joint
-#  required_drive_mode: 3
+torso_2_joint_velocity_controller:
+  type: velocity_controllers/JointVelocityController
+  joint: torso_2_joint
+  required_drive_mode: 3
+torso_3_joint_velocity_controller:
+  type: velocity_controllers/JointVelocityController
+  joint: torso_3_joint
+  required_drive_mode: 3


### PR DESCRIPTION
did not prove helpful, thus removing (see also https://github.com/ipa320/cob_control/commit/0ea6aede231ed608078c4414845f517ab5bb8f31 in https://github.com/ipa320/cob_control/pull/99
