### PR TITLE
Deleted unused parameter

### DIFF
--- a/cob_hardware_config/cob4-3/config/teleop.yaml
+++ b/cob_hardware_config/cob4-3/config/teleop.yaml
@@ -17,7 +17,6 @@ safety_button: 4
 init_button: 7
 
 #mode1: Base
-run_button: 
 
 components: {
   base: {

--- a/cob_hardware_config/cob4-4/config/teleop.yaml
+++ b/cob_hardware_config/cob4-4/config/teleop.yaml
@@ -17,7 +17,6 @@ safety_button: 4
 init_button: 7
 
 #mode1: Base
-run_button: 
 
 components: {
   base: {

--- a/cob_hardware_config/cob4-6/config/teleop.yaml
+++ b/cob_hardware_config/cob4-6/config/teleop.yaml
@@ -17,7 +17,6 @@ safety_button: 4
 init_button: 7
 
 #mode1: Base
-run_button: 
 
 components: {
   base: {


### PR DESCRIPTION
roslaunch returns with error because the parameter is defined and not set
