### PR TITLE
never allow collissions for base/torso and torso/head

### DIFF
--- a/cob_hardware_config/cob4-1/srdf/cob4-1.srdf
+++ b/cob_hardware_config/cob4-1/srdf/cob4-1.srdf
@@ -1,3 +1,9 @@
 <?xml version="1.0" ?>
 <robot name="cob4-1">
+    <disable_collisions link1="base_link" link2="torso_1_link" reason="Never" />
+    <disable_collisions link1="base_link" link2="torso_2_link" reason="Never" />
+    <disable_collisions link1="base_link" link2="torso_3_link" reason="Never" />
+    <disable_collisions link1="torso_3_link" link2="head_1_link" reason="Never" />
+    <disable_collisions link1="torso_3_link" link2="head_2_link" reason="Never" />
+    <disable_collisions link1="torso_3_link" link2="head_3_link" reason="Never" />
 </robot>

--- a/cob_hardware_config/cob4-2/srdf/cob4-2.srdf
+++ b/cob_hardware_config/cob4-2/srdf/cob4-2.srdf
@@ -1,3 +1,9 @@
 <?xml version="1.0" ?>
 <robot name="cob4-2">
+    <disable_collisions link1="base_link" link2="torso_1_link" reason="Never" />
+    <disable_collisions link1="base_link" link2="torso_2_link" reason="Never" />
+    <disable_collisions link1="base_link" link2="torso_3_link" reason="Never" />
+    <disable_collisions link1="torso_3_link" link2="head_1_link" reason="Never" />
+    <disable_collisions link1="torso_3_link" link2="head_2_link" reason="Never" />
+    <disable_collisions link1="torso_3_link" link2="head_3_link" reason="Never" />
 </robot>


### PR DESCRIPTION
prevents the collission_monitor to send `state=false` due to colliding meshes. needed for head movements of cob4-1.
