### PR TITLE
use dummy state publisher instead of real collission monitor

### DIFF
--- a/cob_bringup/package.xml
+++ b/cob_bringup/package.xml
@@ -77,6 +77,7 @@
   <exec_depend>prace_gripper_driver</exec_depend>
   <exec_depend>prosilica_camera</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>rostopic</exec_depend>
   <exec_depend>rplidar_ros</exec_depend> <!-- from cob_substitute -->
   <exec_depend>rviz</exec_depend>
   <exec_depend>schunk_powercube_chain</exec_depend>

--- a/cob_bringup/robots/cob4-1.xml
+++ b/cob_bringup/robots/cob4-1.xml
@@ -47,7 +47,7 @@
 		</include>
 		<!--include file="$(find cob_bringup)/tools/collision_monitor.launch" >
 		</include-->
-		<node pkg="rostopic" type="pub" args="/safety_controller/state_is_valid std_msgs/Bool 'data: false' -r10" name="fake_collission_monitor" output="screen"/>
+		<node pkg="rostopic" type="rostopic" args="pub /safety_controller/state_is_valid std_msgs/Bool 'data: false' -r10" name="fake_collission_monitor" output="screen"/>
 
 		<include file="$(find cob_bringup)/drivers/canopen_402.launch" >
 			<arg name="robot" value="$(arg robot)" />

--- a/cob_bringup/robots/cob4-1.xml
+++ b/cob_bringup/robots/cob4-1.xml
@@ -45,8 +45,9 @@
 		<include file="$(find cob_bringup)/drivers/sick_flexisoft.launch" >
 			<arg name="robot" value="$(arg robot)" />
 		</include>
-		<include file="$(find cob_bringup)/tools/collision_monitor.launch" >
-		</include>
+		<!--include file="$(find cob_bringup)/tools/collision_monitor.launch" >
+		</include-->
+        <node pkg="rostopic" type="pub" args="/safety_controller/state_is_valid std_msgs/Bool 'data: false' -r10" name="fake_collission_monitor" output="screen"/>
 
 		<include file="$(find cob_bringup)/drivers/canopen_402.launch" >
 			<arg name="robot" value="$(arg robot)" />

--- a/cob_bringup/robots/cob4-1.xml
+++ b/cob_bringup/robots/cob4-1.xml
@@ -47,7 +47,7 @@
 		</include>
 		<!--include file="$(find cob_bringup)/tools/collision_monitor.launch" >
 		</include-->
-        <node pkg="rostopic" type="pub" args="/safety_controller/state_is_valid std_msgs/Bool 'data: false' -r10" name="fake_collission_monitor" output="screen"/>
+		<node pkg="rostopic" type="pub" args="/safety_controller/state_is_valid std_msgs/Bool 'data: false' -r10" name="fake_collission_monitor" output="screen"/>
 
 		<include file="$(find cob_bringup)/drivers/canopen_402.launch" >
 			<arg name="robot" value="$(arg robot)" />

--- a/cob_bringup/robots/cob4-2.xml
+++ b/cob_bringup/robots/cob4-2.xml
@@ -45,8 +45,9 @@
 		<include file="$(find cob_bringup)/drivers/sick_flexisoft.launch" >
 			<arg name="robot" value="$(arg robot)" />
 		</include>
-		<include file="$(find cob_bringup)/tools/collision_monitor.launch" >
-		</include>
+		<!--include file="$(find cob_bringup)/tools/collision_monitor.launch" >
+		</include-->
+		<node pkg="rostopic" type="pub" args="/safety_controller/state_is_valid std_msgs/Bool 'data: false' -r10" name="fake_collission_monitor" output="screen"/>
 
 		<include file="$(find cob_bringup)/drivers/canopen_402.launch" >
 			<arg name="robot" value="$(arg robot)" />

--- a/cob_bringup/robots/cob4-2.xml
+++ b/cob_bringup/robots/cob4-2.xml
@@ -47,7 +47,7 @@
 		</include>
 		<!--include file="$(find cob_bringup)/tools/collision_monitor.launch" >
 		</include-->
-		<node pkg="rostopic" type="pub" args="/safety_controller/state_is_valid std_msgs/Bool 'data: false' -r10" name="fake_collission_monitor" output="screen"/>
+		<node pkg="rostopic" type="rostopic" args="pub /safety_controller/state_is_valid std_msgs/Bool 'data: false' -r10" name="fake_collission_monitor" output="screen"/>
 
 		<include file="$(find cob_bringup)/drivers/canopen_402.launch" >
 			<arg name="robot" value="$(arg robot)" />


### PR DESCRIPTION
current setup with collission monitor is not working reliably yet. Sometimes there is a `is_valid=False` which causes an emergency stop.

This PR should be reverted as soons as the collission monitor is working fine.

tested on cob4-1/cob4-2: OK
