### PR TITLE
disabled battery monitor sound/light and emmonitor sound

### DIFF
--- a/cob_hardware_config/cob4-2/config/battery_monitor.yaml
+++ b/cob_hardware_config/cob4-2/config/battery_monitor.yaml
@@ -2,9 +2,9 @@ threshold_warning: 20 # % of battery level
 threshold_error: 10 # % of battery level
 threshold_critical: 5 # % of battery level
 
-enable_light: true
+enable_light: false
 num_leds: 58
 light_components: ['light_torso']
 
-enable_sound: true
+enable_sound: false
 sound_components: ['sound']

--- a/cob_hardware_config/cob4-2/config/emergency_stop_monitor.yaml
+++ b/cob_hardware_config/cob4-2/config/emergency_stop_monitor.yaml
@@ -2,7 +2,7 @@ enable_light: true
 light_components: ['light_base']
 color_ok: cyan
 
-enable_sound: true
+enable_sound: false
 sound_components: ['sound']
 
 diagnostics_based: true


### PR DESCRIPTION
disabled battery_monitors sound + light and emergency monitors sound output.
Done because the bms is always reporting low battery and in case of msh scenario we do not like to have sound output if em is active.
