### PR TITLE
3d camera performance improvements

### DIFF
--- a/cob_bringup/drivers/openni2.launch
+++ b/cob_bringup/drivers/openni2.launch
@@ -5,7 +5,7 @@
 	<arg name="name" default="cam3d"/>
 	<arg name="device_id" default="#1"/>
 
-	<param name="/$(arg name)/driver/data_skip" type="int" value="5"/>
+	<param name="/$(arg name)/driver/data_skip" type="int" value="0"/>
 	<param name="/$(arg name)/driver/image_mode" type="int" value="5"/>
 	<param name="/$(arg name)/driver/depth_mode" type="int" value="5"/>
 	<param name="/$(arg name)/driver/z_offset_mm" type="int" value="20"/>

--- a/cob_bringup/robots/cob4-1.xml
+++ b/cob_bringup/robots/cob4-1.xml
@@ -169,6 +169,7 @@
 			<arg name="robot" value="$(arg robot)" />
 			<arg name="camera_name" value="torso_cam3d_right"/>
 			<arg name="nodelet_manager" value="torso_cam3d_right_nodelet_manager"/>
+			<arg name="start_manager" value="false"/>
 		</include>
 	</group>
 
@@ -190,6 +191,7 @@
 			<arg name="robot" value="$(arg robot)" />
 			<arg name="camera_name" value="torso_cam3d_left"/>
 			<arg name="nodelet_manager" value="torso_cam3d_left_nodelet_manager"/>
+			<arg name="start_manager" value="false"/>
 		</include>
 
 		<!--include file="$(find cob_bringup)/drivers/softkinetic.launch" >

--- a/cob_bringup/robots/cob4-2.xml
+++ b/cob_bringup/robots/cob4-2.xml
@@ -199,6 +199,7 @@
 			<arg name="robot" value="$(arg robot)" />
 			<arg name="camera_name" value="torso_cam3d_right"/>
 			<arg name="nodelet_manager" value="torso_cam3d_right_nodelet_manager"/>
+			<arg name="start_manager" value="false"/>
 		</include>
 	</group>
 
@@ -225,6 +226,7 @@
 			<arg name="robot" value="$(arg robot)" />
 			<arg name="camera_name" value="torso_cam3d_left"/>
 			<arg name="nodelet_manager" value="torso_cam3d_left_nodelet_manager"/>
+			<arg name="start_manager" value="false"/>
 		</include>
 
 		<!--include file="$(find cob_bringup)/drivers/softkinetic.launch" >


### PR DESCRIPTION
- Start image flip inside the same nodelet manager as the camera is running. Otherwise using nodelets is nonsense
- inside openni2.launch was a param `data_skip` with the value 5. This means that only every fifths data package is used. Can somebody explain me why this was set? The result of this was a frame rate of 5-6 fps. Now we achieve 30 fps!
