### PR TITLE
Delete .travis.rosinstall

### DIFF
--- a/.travis.rosinstall
+++ b/.travis.rosinstall
@@ -1,8 +1,0 @@
-- git:
-    uri: 'https://github.com/ipa320/cob_driver.git'
-    local-name: cob_driver
-    version: indigo_dev
-- git:
-    uri: 'https://github.com/ipa320/cob_manipulation.git'
-    local-name: cob_manipulation
-    version: indigo_dev


### PR DESCRIPTION
if no .travis.rosinstall is found, travis will use the default one from https://github.com/ipa320/care-o-bot/blob/indigo_dev/.travis.rosinstall
