### PR TITLE
Updated cob4-3 config

### DIFF
--- a/cob_bringup/drivers/bms.launch
+++ b/cob_bringup/drivers/bms.launch
@@ -4,7 +4,7 @@
 	<arg name="robot" default="$(optenv ROBOT !!NO_ROBOT_SET!!)"/>
 	<arg name="pkg_hardware_config" default="$(find cob_hardware_config)"/>
 
-	<node name="bms" pkg="cob_bms_driver" type="bms_driver_node" output="screen" clear_params="true" respawn="true">
+	<node name="bms" pkg="cob_bms_driver" type="bms_driver_node" output="screen" clear_params="true">
 		<rosparam command="load" file="$(arg pkg_hardware_config)/$(arg robot)/config/bms.yaml"/>
 	</node>
 	<node ns="bms" name="power_state_aggregator" pkg="cob_bms_driver" type="power_state_aggregator.py" output="screen">

--- a/cob_bringup/package.xml
+++ b/cob_bringup/package.xml
@@ -44,6 +44,7 @@
   <exec_depend>cob_moveit_config</exec_depend>
   <exec_depend>cob_obstacle_distance</exec_depend>
   <exec_depend>cob_obstacle_distance_moveit</exec_depend>
+  <exec_depend>cob_omni_drive_controller</exec_depend>
   <exec_depend>cob_phidgets</exec_depend>
   <exec_depend>cob_phidget_power_state</exec_depend>
   <exec_depend>cob_relayboard</exec_depend>

--- a/cob_bringup/robots/cob4-3.xml
+++ b/cob_bringup/robots/cob4-3.xml
@@ -31,6 +31,10 @@
 		<include file="$(find cob_bringup)/controllers/base_controller_plugin.launch">
 			<arg name="robot" value="$(arg robot)"/>
 		</include>
+		<include file="$(find cob_omni_drive_controller)/launch/stuck_detector.launch">
+			<arg name="timeout" default="2.0" />
+			<arg name="threshold" default="0.174533" /> 
+		</include>
 
 		<!-- start additional packages -->
 		<include file="$(find cob_bringup)/tools/diagnostics_aggregator.launch" >

--- a/cob_hardware_config/cob4-3/config/base_controller.yaml
+++ b/cob_hardware_config/cob4-3/config/base_controller.yaml
@@ -28,6 +28,7 @@ twist_controller:
       drive: fl_caster_r_wheel_joint
     - steer: b_caster_rotation_joint
       drive: b_caster_r_wheel_joint
+      steer_neutral_position: -180.0
     - steer: fr_caster_rotation_joint
       drive: fr_caster_r_wheel_joint
 

--- a/cob_hardware_config/cob4-3/config/base_controller.yaml
+++ b/cob_hardware_config/cob4-3/config/base_controller.yaml
@@ -12,6 +12,7 @@ twist_controller:
   required_drive_mode: 3
   #max_rot_velocity: 1.0
   #max_trans_velocity: 1.0
+  pub_divider: 1
   timeout: 0.5
 
   defaults: # default settings for all wheels, can per overwritten per wheel

--- a/cob_hardware_config/cob4-3/config/base_driver.yaml
+++ b/cob_hardware_config/cob4-3/config/base_driver.yaml
@@ -19,11 +19,13 @@ defaults:
     "1803sub2" : "1" # enable TPDO3 on sync
     "1A03sub0" : "1" # one entry for TPDO3
     "1A03sub1" : "0x60780010" # actual current 
+  eff_from_device: "obj6078/1000.0*9.76" #CL[1]=9.76 
 
 drive_wheel: &drive_wheel
   dcf_overlay: # "ObjectID" : "ParameterValue" (both as strings)
     "6098": "35" # homing method
   vel_from_device: "p1 != p1 || obj2041 == t1 ? 0 : deg2rad(1000*norm(obj6064-p1,-36000000,36000000)/norm(obj2041-t1,0,2^32)), p1=p0, p0 = obj6064, t1 = t0, t0 = obj2041"
+  eff_from_device: "obj6078/1000.0*14.14" #CL[1]=14.14
 
 nodes:
   ##Wheel 1

--- a/cob_hardware_config/cob4-3/config/base_driver.yaml
+++ b/cob_hardware_config/cob4-3/config/base_driver.yaml
@@ -28,7 +28,7 @@ nodes:
     id: 1
     dcf_overlay: # "ObjectID" : "ParameterValue" (both as strings)
       "6098": "19" # homing method
-      "607C": "-51445"# home offset
+      "607C": "-51776"# home offset
   fl_caster_r_wheel_joint:
     <<: *drive_wheel
     id: 2
@@ -38,7 +38,7 @@ nodes:
     id: 3
     dcf_overlay: # "ObjectID" : "ParameterValue" (both as strings)
       "6098": "19" # homing method
-      "607C": "-174876.0" # home offset
+      "607C": "-173177" # home offset
   b_caster_r_wheel_joint:
     <<: *drive_wheel
     id: 4
@@ -48,7 +48,7 @@ nodes:
     id: 5
     dcf_overlay: # "ObjectID" : "ParameterValue" (both as strings)
       "6098": "19" # homing method
-      "607C": "67570.5" # home offset
+      "607C": "67565" # home offset
   fr_caster_r_wheel_joint:
     <<: *drive_wheel
     id: 6

--- a/cob_hardware_config/cob4-3/config/base_driver.yaml
+++ b/cob_hardware_config/cob4-3/config/base_driver.yaml
@@ -16,6 +16,9 @@ defaults:
     "6099sub1": "100000" # find switch (coarse)
     "6099sub2": "10000" # find home (fine)
     "1016sub1" : "0x7F0064" # heartbeat timeout of 100 ms for master at 127
+    "1803sub2" : "1" # enable TPDO3 on sync
+    "1A03sub0" : "1" # one entry for TPDO3
+    "1A03sub1" : "0x60780010" # actual current 
 
 drive_wheel: &drive_wheel
   dcf_overlay: # "ObjectID" : "ParameterValue" (both as strings)

--- a/cob_hardware_config/cob4-3/config/diagnostics_analyzers.yaml
+++ b/cob_hardware_config/cob4-3/config/diagnostics_analyzers.yaml
@@ -41,6 +41,6 @@ analyzers:
     path: Sensors
     analyzers:
       battery:
-        type: diagnostic_aggregator/GenericAnalyzer
+        type: diagnostic_aggregator/IgnoreAnalyzer
         path: Battery Status
         contains: 'bms'


### PR DESCRIPTION
- ignore BMS in diagnostics aggregator (**should be reverted later**)
- base calibration
- read currents and include them in joint_states
- stuck detector (needs https://github.com/ipa320/cob_control/pull/111)
- **do not respawn BMS driver**
