### PR TITLE
add diagnostics hz monitor to cob4-1 and cob4-2 for cameras

### DIFF
--- a/cob_bringup/robots/cob4-1.xml
+++ b/cob_bringup/robots/cob4-1.xml
@@ -151,6 +151,10 @@
         <include file="$(find realsense_camera)/launch/r200_nodelet_rgbd.launch">
             <arg name="camera" value="torso_cam3d_down"/>
         </include>
+        <include file="$(find cob_bringup)/tools/hz_monitor.launch">
+            <arg name="robot" value="$(arg robot)"/>
+            <arg name="yaml_name" value="torso_cam3d_down"/>
+        </include>
         <include file="$(find cob_bringup)/drivers/image_flip_nodelet.launch">
             <arg name="robot" value="$(arg robot)"/>
             <arg name="camera_name" value="torso_cam3d_down"/>
@@ -176,7 +180,10 @@
             <arg name="name" value="torso_cam3d_right"/>
             <arg name="device_id" value="#1"/>
         </include>
-
+        <include file="$(find cob_bringup)/tools/hz_monitor.launch">
+            <arg name="robot" value="$(arg robot)"/>
+            <arg name="yaml_name" value="torso_cam3d_right"/>
+        </include>
         <include file="$(find cob_bringup)/drivers/image_flip_nodelet.launch">
             <arg name="robot" value="$(arg robot)"/>
             <arg name="camera_name" value="torso_cam3d_right"/>
@@ -198,7 +205,10 @@
             <arg name="name" value="torso_cam3d_left"/>
             <arg name="device_id" value="#1"/>
         </include>
-
+        <include file="$(find cob_bringup)/tools/hz_monitor.launch">
+            <arg name="robot" value="$(arg robot)"/>
+            <arg name="yaml_name" value="torso_cam3d_left"/>
+        </include>
         <include file="$(find cob_bringup)/drivers/image_flip_nodelet.launch">
             <arg name="robot" value="$(arg robot)"/>
             <arg name="camera_name" value="torso_cam3d_left"/>
@@ -219,7 +229,10 @@
             <arg name="robot" value="$(arg robot)"/>
             <arg name="name" value="sensorring_cam3d"/>
         </include>
-
+        <include file="$(find cob_bringup)/tools/hz_monitor.launch">
+            <arg name="robot" value="$(arg robot)"/>
+            <arg name="yaml_name" value="sensorring_cam3d"/>
+        </include>
         <include file="$(find cob_bringup)/drivers/image_flip_nodelet.launch">
             <arg name="robot" value="$(arg robot)"/>
             <arg name="camera_name" value="sensorring_cam3d"/>
@@ -242,7 +255,10 @@
         <include file="$(find cob_bringup)/drivers/usb_camera_node.launch">
             <arg name="camera_name" value="head_cam"/>
         </include>
-
+        <include file="$(find cob_bringup)/tools/hz_monitor.launch">
+            <arg name="robot" value="$(arg robot)"/>
+            <arg name="yaml_name" value="head_cam"/>
+        </include>
         <include file="$(find cob_bringup)/drivers/image_flip.launch">
             <arg name="robot" value="$(arg robot)"/>
             <arg name="camera_name" value="head_cam"/>

--- a/cob_bringup/robots/cob4-2.xml
+++ b/cob_bringup/robots/cob4-2.xml
@@ -182,6 +182,10 @@
         <include file="$(find realsense_camera)/launch/r200_nodelet_rgbd.launch">
             <arg name="camera" value="torso_cam3d_down"/>
         </include>
+        <include file="$(find cob_bringup)/tools/hz_monitor.launch">
+            <arg name="robot" value="$(arg robot)"/>
+            <arg name="yaml_name" value="torso_cam3d_down"/>
+        </include>
         <include file="$(find cob_bringup)/drivers/image_flip_nodelet.launch">
             <arg name="robot" value="$(arg robot)"/>
             <arg name="camera_name" value="torso_cam3d_down"/>
@@ -213,7 +217,10 @@
             <arg name="name" value="torso_cam3d_right"/>
             <arg name="device_id" value="#1"/>
         </include>
-
+        <include file="$(find cob_bringup)/tools/hz_monitor.launch">
+            <arg name="robot" value="$(arg robot)"/>
+            <arg name="yaml_name" value="torso_cam3d_right"/>
+        </include>
         <include file="$(find cob_bringup)/drivers/image_flip_nodelet.launch">
             <arg name="robot" value="$(arg robot)"/>
             <arg name="camera_name" value="torso_cam3d_right"/>
@@ -240,7 +247,10 @@
             <arg name="name" value="torso_cam3d_left"/>
             <arg name="device_id" value="#1"/>
         </include>
-
+        <include file="$(find cob_bringup)/tools/hz_monitor.launch">
+            <arg name="robot" value="$(arg robot)"/>
+            <arg name="yaml_name" value="torso_cam3d_left"/>
+        </include>
         <include file="$(find cob_bringup)/drivers/image_flip_nodelet.launch">
             <arg name="robot" value="$(arg robot)"/>
             <arg name="camera_name" value="torso_cam3d_left"/>
@@ -261,7 +271,10 @@
             <arg name="robot" value="$(arg robot)"/>
             <arg name="name" value="sensorring_cam3d"/>
         </include>
-
+        <include file="$(find cob_bringup)/tools/hz_monitor.launch">
+            <arg name="robot" value="$(arg robot)"/>
+            <arg name="yaml_name" value="sensorring_cam3d"/>
+        </include>
         <include file="$(find cob_bringup)/drivers/image_flip_nodelet.launch">
             <arg name="robot" value="$(arg robot)"/>
             <arg name="camera_name" value="sensorring_cam3d"/>
@@ -284,7 +297,10 @@
         <include file="$(find cob_bringup)/drivers/usb_camera_node.launch">
             <arg name="camera_name" value="head_cam"/>
         </include>
-
+        <include file="$(find cob_bringup)/tools/hz_monitor.launch">
+            <arg name="robot" value="$(arg robot)"/>
+            <arg name="yaml_name" value="head_cam"/>
+        </include>
         <include file="$(find cob_bringup)/drivers/image_flip.launch">
             <arg name="robot" value="$(arg robot)"/>
             <arg name="camera_name" value="head_cam"/>

--- a/cob_bringup/tools/hz_monitor.launch
+++ b/cob_bringup/tools/hz_monitor.launch
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<launch>
+
+	<arg name="yaml_name"/>
+	<arg name="robot" default="$(optenv ROBOT !!NO_ROBOT_SET!!)"/>
+	<arg name="pkg_hardware_config" default="$(find cob_hardware_config)"/>
+
+	<!-- start hz monitor node -->
+	<node name="hz_monitor_$(arg yaml_name)" pkg="cob_monitoring" type="hz_monitor.py" respawn="false" output="screen">
+		<rosparam command="load" file="$(arg pkg_hardware_config)/$(arg robot)/config/hz_monitor_$(arg yaml_name).yaml"/>
+		<remap from="~diagnostics" to="/diagnostics"/>
+	</node>
+
+</launch>

--- a/cob_hardware_config/cob4-1/config/diagnostics_analyzers.yaml
+++ b/cob_hardware_config/cob4-1/config/diagnostics_analyzers.yaml
@@ -72,6 +72,26 @@ analyzers:
         type: diagnostic_aggregator/GenericAnalyzer
         path: Scan Left
         contains: 'laser_left'
+      torso_cam3d_left:
+        type: diagnostic_aggregator/GenericAnalyzer
+        path: Torso Cam3d Left
+        contains: 'torso_cam3d_left'
+      torso_cam3d_right:
+        type: diagnostic_aggregator/GenericAnalyzer
+        path: Torso Cam3d Right
+        contains: 'torso_cam3d_right'
+      torso_cam3d_down:
+        type: diagnostic_aggregator/GenericAnalyzer
+        path: Torso Cam3d Down
+        contains: 'torso_cam3d_down'
+      sensorring_cam3d:
+        type: diagnostic_aggregator/GenericAnalyzer
+        path: Sensorring Cam3d
+        contains: 'sensorring_cam3d'
+      head_cam:
+        type: diagnostic_aggregator/GenericAnalyzer
+        path: Head Cam
+        contains: 'head_cam'
 #      battery:
 #        type: diagnostic_aggregator/GenericAnalyzer
 #        path: Battery Status

--- a/cob_hardware_config/cob4-1/config/hz_monitor_head_cam.yaml
+++ b/cob_hardware_config/cob4-1/config/hz_monitor_head_cam.yaml
@@ -1,0 +1,1 @@
+../../cob4-2/config/hz_monitor_head_cam.yaml

--- a/cob_hardware_config/cob4-1/config/hz_monitor_sensorring_cam3d.yaml
+++ b/cob_hardware_config/cob4-1/config/hz_monitor_sensorring_cam3d.yaml
@@ -1,0 +1,1 @@
+../../cob4-2/config/hz_monitor_sensorring_cam3d.yaml

--- a/cob_hardware_config/cob4-1/config/hz_monitor_torso_cam3d_down.yaml
+++ b/cob_hardware_config/cob4-1/config/hz_monitor_torso_cam3d_down.yaml
@@ -1,0 +1,1 @@
+../../cob4-2/config/hz_monitor_torso_cam3d_down.yaml

--- a/cob_hardware_config/cob4-1/config/hz_monitor_torso_cam3d_left.yaml
+++ b/cob_hardware_config/cob4-1/config/hz_monitor_torso_cam3d_left.yaml
@@ -1,0 +1,1 @@
+../../cob4-2/config/hz_monitor_torso_cam3d_left.yaml

--- a/cob_hardware_config/cob4-1/config/hz_monitor_torso_cam3d_right.yaml
+++ b/cob_hardware_config/cob4-1/config/hz_monitor_torso_cam3d_right.yaml
@@ -1,0 +1,1 @@
+../../cob4-2/config/hz_monitor_torso_cam3d_right.yaml

--- a/cob_hardware_config/cob4-2/config/diagnostics_analyzers.yaml
+++ b/cob_hardware_config/cob4-2/config/diagnostics_analyzers.yaml
@@ -72,6 +72,26 @@ analyzers:
         type: diagnostic_aggregator/GenericAnalyzer
         path: Scan Left
         contains: 'laser_left'
+      torso_cam3d_left:
+        type: diagnostic_aggregator/GenericAnalyzer
+        path: Torso Cam3d Left
+        contains: 'torso_cam3d_left'
+      torso_cam3d_right:
+        type: diagnostic_aggregator/GenericAnalyzer
+        path: Torso Cam3d Right
+        contains: 'torso_cam3d_right'
+      torso_cam3d_down:
+        type: diagnostic_aggregator/GenericAnalyzer
+        path: Torso Cam3d Down
+        contains: 'torso_cam3d_down'
+      sensorring_cam3d:
+        type: diagnostic_aggregator/GenericAnalyzer
+        path: Sensorring Cam3d
+        contains: 'sensorring_cam3d'
+      head_cam:
+        type: diagnostic_aggregator/GenericAnalyzer
+        path: Head Cam
+        contains: 'head_cam'
 #      battery:
 #        type: diagnostic_aggregator/GenericAnalyzer
 #        path: Battery Status

--- a/cob_hardware_config/cob4-2/config/hz_monitor_head_cam.yaml
+++ b/cob_hardware_config/cob4-2/config/hz_monitor_head_cam.yaml
@@ -1,0 +1,3 @@
+topic: /head_cam/image_raw
+hz: 30
+hzerror: 1

--- a/cob_hardware_config/cob4-2/config/hz_monitor_sensorring_cam3d.yaml
+++ b/cob_hardware_config/cob4-2/config/hz_monitor_sensorring_cam3d.yaml
@@ -1,0 +1,3 @@
+topic: /sensorring_cam3d/rgb/image_raw
+hz: 30
+hzerror: 1

--- a/cob_hardware_config/cob4-2/config/hz_monitor_torso_cam3d_down.yaml
+++ b/cob_hardware_config/cob4-2/config/hz_monitor_torso_cam3d_down.yaml
@@ -1,0 +1,3 @@
+topic: /torso_cam3d_down/rgb/image_raw
+hz: 30
+hzerror: 1

--- a/cob_hardware_config/cob4-2/config/hz_monitor_torso_cam3d_left.yaml
+++ b/cob_hardware_config/cob4-2/config/hz_monitor_torso_cam3d_left.yaml
@@ -1,0 +1,3 @@
+topic: /torso_cam3d_left/rgb/image_raw
+hz: 30
+hzerror: 1

--- a/cob_hardware_config/cob4-2/config/hz_monitor_torso_cam3d_right.yaml
+++ b/cob_hardware_config/cob4-2/config/hz_monitor_torso_cam3d_right.yaml
@@ -1,0 +1,3 @@
+topic: /torso_cam3d_right/rgb/image_raw
+hz: 30
+hzerror: 1


### PR DESCRIPTION
requires https://github.com/ipa320/cob_command_tools/pull/157. Retrigger travis after https://github.com/ipa320/cob_command_tools/pull/157 is merged.
