### PR TITLE
added env.sh plath as argument

### DIFF
--- a/cob_bringup/robot.launch
+++ b/cob_bringup/robot.launch
@@ -3,7 +3,10 @@
 
 	<param name="/use_sim_time" value="false"/>
 	<arg name="robot" default="$(optenv ROBOT !!NO_ROBOT_SET!!)"/>
+	<arg name="env-script" default="$(find cob_bringup)/env.sh"/>
 
-	<include file="$(find cob_bringup)/robots/$(arg robot).launch"/>
+	<include file="$(find cob_bringup)/robots/$(arg robot).launch">
+		<arg name="env-script" value="$(arg env-script)"/>
+	</include>
 
 </launch>

--- a/cob_bringup/robots/cob3-2.launch
+++ b/cob_bringup/robots/cob3-2.launch
@@ -1,10 +1,13 @@
 <?xml version="1.0"?>
 <launch>
 
+	<arg name="env-script" default="$(find cob_bringup)/env.sh"/>
+
 	<include file="$(find cob_bringup)/robots/cob3-2.xml" >
 		<arg name="pc1" value="cob3-2-pc1"/>
 		<arg name="pc2" value="cob3-2-pc2"/>
 		<arg name="pc3" value="cob3-2-pc3"/>
+		<arg name="env-script" value="$(arg env-script)"/>
 	</include>
 
 </launch>

--- a/cob_bringup/robots/cob3-2.xml
+++ b/cob_bringup/robots/cob3-2.xml
@@ -6,6 +6,8 @@
 	<arg name="pc1" default="localhost"/>
 	<arg name="pc2" default="localhost"/>
 	<arg name="pc3" default="localhost"/>
+	<arg name="env-script" default="$(find cob_bringup)/env.sh"/>
+
 
 	<!-- upload robot description -->
 	<include file="$(find cob_hardware_config)/common/upload_robot.launch" >
@@ -16,7 +18,7 @@
 	<include file="$(find cob_default_robot_config)/cob3-2/upload_param_cob3-2.launch" />
 
 	<group>
-		<machine name="pc1" address="$(arg pc1)" env-loader="$(find cob_bringup)/env.sh" default="true" timeout="30"/>
+		<machine name="pc1" address="$(arg pc1)" env-loader="$(arg env-script)" default="true" timeout="30"/>
 
 		<include file="$(find cob_bringup)/tools/pc_monitor.launch" >
 			<arg name="robot" value="$(arg robot)" />
@@ -140,7 +142,7 @@
 	</group>
 
 	<group>
-		<machine name="pc2" address="$(arg pc2)" env-loader="$(find cob_bringup)/env.sh" default="true" timeout="30"/>
+		<machine name="pc2" address="$(arg pc2)" env-loader="$(arg env-script)" default="true" timeout="30"/>
 
 		<include file="$(find cob_bringup)/tools/pc_monitor.launch" >
 			<arg name="robot" value="$(arg robot)" />
@@ -167,7 +169,7 @@
 	</group>
 
 	<group>
-		<machine name="pc3" address="$(arg pc3)" env-loader="$(find cob_bringup)/env.sh" default="true" timeout="30"/>
+		<machine name="pc3" address="$(arg pc3)" env-loader="$(arg env-script)" default="true" timeout="30"/>
 
 		<include file="$(find cob_bringup)/tools/pc_monitor.launch" >
 			<arg name="robot" value="$(arg robot)" />
@@ -182,6 +184,6 @@
 		</include>
 	</group>
 
-	<machine name="pc1" address="$(arg pc1)" env-loader="$(find cob_bringup)/env.sh" default="true" timeout="30"/>
+	<machine name="pc1" address="$(arg pc1)" env-loader="$(arg env-script)" default="true" timeout="30"/>
 
 </launch>

--- a/cob_bringup/robots/cob3-6.launch
+++ b/cob_bringup/robots/cob3-6.launch
@@ -1,9 +1,12 @@
 <?xml version="1.0"?>
 <launch>
 
+	<arg name="env-script" default="$(find cob_bringup)/env.sh"/>
+
 	<include file="$(find cob_bringup)/robots/cob3-6.xml" >
 		<arg name="pc1" value="cob3-6-pc1"/>
 		<arg name="pc2" value="cob3-6-pc2"/>
+		<arg name="env-script" value="$(arg env-script)"/>
 	</include>
 
 </launch>

--- a/cob_bringup/robots/cob3-6.xml
+++ b/cob_bringup/robots/cob3-6.xml
@@ -5,6 +5,8 @@
 	<arg name="robot" value="cob3-6"/>
 	<arg name="pc1" default="localhost"/>
 	<arg name="pc2" default="localhost"/>
+	<arg name="env-script" default="$(find cob_bringup)/env.sh"/>
+
 
 	<!-- upload robot description -->
 	<include file="$(find cob_hardware_config)/common/upload_robot.launch" >
@@ -15,7 +17,7 @@
 	<include file="$(find cob_default_robot_config)/cob3-6/upload_param_cob3-6.launch" />
 
 	<group>
-		<machine name="pc1" address="$(arg pc1)" env-loader="$(find cob_bringup)/env.sh" default="true" timeout="30"/>
+		<machine name="pc1" address="$(arg pc1)" env-loader="$(arg env-script)" default="true" timeout="30"/>
 
 		<include file="$(find cob_bringup)/tools/pc_monitor.launch" >
 			<arg name="robot" value="$(arg robot)" />
@@ -115,7 +117,7 @@
 	</group>
 
 	<group>
-		<machine name="pc2" address="$(arg pc2)" env-loader="$(find cob_bringup)/env.sh" default="true" timeout="30"/>
+		<machine name="pc2" address="$(arg pc2)" env-loader="$(arg env-script)" default="true" timeout="30"/>
 
 		<include file="$(find cob_bringup)/tools/pc_monitor.launch" >
 			<arg name="robot" value="$(arg robot)" />
@@ -166,6 +168,6 @@
 		</include>
 	</group>
 
-	<machine name="pc1" address="$(arg pc1)" env-loader="$(find cob_bringup)/env.sh" default="true" timeout="30"/>
+	<machine name="pc1" address="$(arg pc1)" env-loader="$(arg env-script)" default="true" timeout="30"/>
 
 </launch>

--- a/cob_bringup/robots/cob3-9.launch
+++ b/cob_bringup/robots/cob3-9.launch
@@ -1,10 +1,13 @@
 <?xml version="1.0"?>
 <launch>
 
+	<arg name="env-script" default="$(find cob_bringup)/env.sh"/>
+
 	<include file="$(find cob_bringup)/robots/cob3-9.xml" >
 		<arg name="pc1" value="cob3-9-pc1"/>
 		<arg name="pc2" value="cob3-9-pc2"/>
 		<arg name="pc3" value="cob3-9-pc3"/>
+		<arg name="env-script" value="$(arg env-script)"/>
 	</include>
 
 </launch>

--- a/cob_bringup/robots/cob3-9.xml
+++ b/cob_bringup/robots/cob3-9.xml
@@ -6,6 +6,7 @@
 	<arg name="pc1" default="localhost"/>
 	<arg name="pc2" default="localhost"/>
 	<arg name="pc3" default="localhost"/>
+	<arg name="env-script" default="$(find cob_bringup)/env.sh"/>
 
 	<!-- upload robot description -->
 	<include file="$(find cob_hardware_config)/common/upload_robot.launch" >
@@ -16,7 +17,7 @@
 	<include file="$(find cob_default_robot_config)/cob3-9/upload_param_cob3-9.launch" />
 
 	<group>
-		<machine name="pc1" address="$(arg pc1)" env-loader="$(find cob_bringup)/env.sh" default="true" timeout="30"/>
+		<machine name="pc1" address="$(arg pc1)" env-loader="$(arg env-script)" default="true" timeout="30"/>
 
 		<include file="$(find cob_bringup)/tools/pc_monitor.launch" >
 			<arg name="robot" value="$(arg robot)" />
@@ -120,7 +121,7 @@
 	</group>
 
 	<group>
-		<machine name="pc2" address="$(arg pc2)" env-loader="$(find cob_bringup)/env.sh" default="true" timeout="30"/>
+		<machine name="pc2" address="$(arg pc2)" env-loader="$(arg env-script)" default="true" timeout="30"/>
 
 		<include file="$(find cob_bringup)/tools/pc_monitor.launch" >
 			<arg name="robot" value="$(arg robot)" />
@@ -175,7 +176,7 @@
 	</group>
 
 	<group>
-		<machine name="pc3" address="$(arg pc3)" env-loader="$(find cob_bringup)/env.sh" default="true" timeout="30"/>
+		<machine name="pc3" address="$(arg pc3)" env-loader="$(arg env-script)" default="true" timeout="30"/>
 
 		<include file="$(find cob_bringup)/tools/pc_monitor.launch" >
 			<arg name="robot" value="$(arg robot)" />
@@ -190,6 +191,6 @@
 		</include>
 	</group>
 
-	<machine name="pc1" address="$(arg pc1)" env-loader="$(find cob_bringup)/env.sh" default="true" timeout="30"/>
+	<machine name="pc1" address="$(arg pc1)" env-loader="$(arg env-script)" default="true" timeout="30"/>
 
 </launch>

--- a/cob_bringup/robots/cob4-1.launch
+++ b/cob_bringup/robots/cob4-1.launch
@@ -1,6 +1,8 @@
 <?xml version="1.0"?>
 <launch>
 
+	<arg name="env-script" default="$(find cob_bringup)/env.sh"/>
+
 	<include file="$(find cob_bringup)/robots/cob4-1.xml" >
 		<!-- cob4-1 is currently a special config setup of cob4-2 hardware -->
 		<arg name="cob4-1-b1" value="cob4-2-b1"/>
@@ -9,6 +11,7 @@
 		<arg name="cob4-1-t3" value="cob4-2-t3"/>
 		<arg name="cob4-1-s1" value="cob4-2-s1"/>
 		<arg name="cob4-1-h1" value="cob4-2-h32"/>
+		<arg name="env-script" value="$(arg env-script)"/>
 	</include>
 
 </launch>

--- a/cob_bringup/robots/cob4-1.xml
+++ b/cob_bringup/robots/cob4-1.xml
@@ -9,6 +9,7 @@
     <arg name="cob4-1-t3" default="localhost"/>
     <arg name="cob4-1-s1" default="localhost"/>
     <arg name="cob4-1-h1" default="localhost"/>
+    <arg name="env-script" default="$(find cob_bringup)/env.sh"/>
 
     <!-- upload robot description -->
     <include file="$(find cob_hardware_config)/common/upload_robot.launch">
@@ -19,7 +20,7 @@
     <include file="$(find cob_default_robot_config)/$(arg robot)/upload_param_$(arg robot).launch"/>
 
     <group>
-        <machine name="cob4-1-b1" address="$(arg cob4-1-b1)" env-loader="$(find cob_bringup)/env.sh" default="true" timeout="30"/>
+        <machine name="cob4-1-b1" address="$(arg cob4-1-b1)" env-loader="$(arg env-script)" default="true" timeout="30"/>
 
         <include file="$(find cob_bringup)/tools/pc_monitor.launch">
             <arg name="robot" value="$(arg robot)"/>
@@ -98,7 +99,7 @@
     </group>
 
     <group>
-        <machine name="cob4-1-t1" address="$(arg cob4-1-t1)" env-loader="$(find cob_bringup)/env.sh" default="true" timeout="30"/>
+        <machine name="cob4-1-t1" address="$(arg cob4-1-t1)" env-loader="$(arg env-script)" default="true" timeout="30"/>
 
         <include file="$(find cob_script_server)/launch/script_server.launch"/>
         <include file="$(find cob_bringup)/tools/android.launch">
@@ -170,7 +171,7 @@
     </group>
 
     <group>
-        <machine name="cob4-1-t2" address="$(arg cob4-1-t2)" env-loader="$(find cob_bringup)/env.sh" default="true" timeout="30"/>
+        <machine name="cob4-1-t2" address="$(arg cob4-1-t2)" env-loader="$(arg env-script)" default="true" timeout="30"/>
         <include file="$(find cob_bringup)/tools/pc_monitor.launch">
             <arg name="robot" value="$(arg robot)"/>
             <arg name="pc" value="$(arg cob4-1-t2)"/>
@@ -194,7 +195,7 @@
     </group>
 
     <group>
-        <machine name="cob4-1-t3" address="$(arg cob4-1-t3)" env-loader="$(find cob_bringup)/env.sh" default="true" timeout="30"/>
+        <machine name="cob4-1-t3" address="$(arg cob4-1-t3)" env-loader="$(arg env-script)" default="true" timeout="30"/>
 
         <include file="$(find cob_bringup)/tools/pc_monitor.launch">
             <arg name="robot" value="$(arg robot)"/>
@@ -219,7 +220,7 @@
     </group>
 
     <group>
-        <machine name="cob4-1-s1" address="$(arg cob4-1-s1)" env-loader="$(find cob_bringup)/env.sh" default="true" timeout="30"/>
+        <machine name="cob4-1-s1" address="$(arg cob4-1-s1)" env-loader="$(arg env-script)" default="true" timeout="30"/>
 
         <include file="$(find cob_bringup)/tools/pc_monitor.launch">
             <arg name="robot" value="$(arg robot)"/>
@@ -243,7 +244,7 @@
     </group>
 
     <group>
-        <machine name="cob4-1-h1" address="$(arg cob4-1-h1)" env-loader="$(find cob_bringup)/env.sh" default="true" timeout="30"/>
+        <machine name="cob4-1-h1" address="$(arg cob4-1-h1)" env-loader="$(arg env-script)" default="true" timeout="30"/>
 
         <include file="$(find cob_bringup)/tools/pc_monitor.launch">
             <arg name="robot" value="$(arg robot)"/>
@@ -269,6 +270,6 @@
         </include>
     </group>
 
-    <machine name="cob4-1-b1" address="$(arg cob4-1-b1)" env-loader="$(find cob_bringup)/env.sh" default="true" timeout="30"/>
+    <machine name="cob4-1-b1" address="$(arg cob4-1-b1)" env-loader="$(arg env-script)" default="true" timeout="30"/>
 
 </launch>

--- a/cob_bringup/robots/cob4-2.launch
+++ b/cob_bringup/robots/cob4-2.launch
@@ -8,6 +8,7 @@
 		<arg name="cob4-2-t3" value="cob4-2-t3"/>
 		<arg name="cob4-2-s1" value="cob4-2-s1"/>
 		<arg name="cob4-2-h1" value="cob4-2-h32"/>
+		<arg name="env-script" value="$(find cob_bringup)/env.sh"/>
 	</include>
 
 </launch>

--- a/cob_bringup/robots/cob4-2.launch
+++ b/cob_bringup/robots/cob4-2.launch
@@ -1,6 +1,8 @@
 <?xml version="1.0"?>
 <launch>
 
+	<arg name="env-script" default="$(find cob_bringup)/env.sh"/>
+
 	<include file="$(find cob_bringup)/robots/cob4-2.xml" >
 		<arg name="cob4-2-b1" value="cob4-2-b1"/>
 		<arg name="cob4-2-t1" value="cob4-2-t1"/>
@@ -8,7 +10,7 @@
 		<arg name="cob4-2-t3" value="cob4-2-t3"/>
 		<arg name="cob4-2-s1" value="cob4-2-s1"/>
 		<arg name="cob4-2-h1" value="cob4-2-h32"/>
-		<arg name="env-script" value="$(find cob_bringup)/env.sh"/>
+		<arg name="env-script" value="$(arg env-script)"/>
 	</include>
 
 </launch>

--- a/cob_bringup/robots/cob4-2.xml
+++ b/cob_bringup/robots/cob4-2.xml
@@ -9,6 +9,7 @@
     <arg name="cob4-2-t3" default="localhost"/>
     <arg name="cob4-2-s1" default="localhost"/>
     <arg name="cob4-2-h1" default="localhost"/>
+    <arg name="env-script" default="$(find cob_bringup)/env.sh"/>
 
     <!-- upload robot description -->
     <include file="$(find cob_hardware_config)/common/upload_robot.launch">
@@ -19,7 +20,7 @@
     <include file="$(find cob_default_robot_config)/$(arg robot)/upload_param_$(arg robot).launch"/>
 
     <group>
-        <machine name="cob4-2-b1" address="$(arg cob4-2-b1)" env-loader="$(find cob_bringup)/env.sh" default="true" timeout="30"/>
+        <machine name="cob4-2-b1" address="$(arg cob4-2-b1)" env-loader="$(arg env-script)" default="true" timeout="30"/>
 
         <include file="$(find cob_bringup)/tools/pc_monitor.launch">
             <arg name="robot" value="$(arg robot)"/>
@@ -99,7 +100,7 @@
     </group>
 
     <group>
-        <machine name="cob4-2-t1" address="$(arg cob4-2-t1)" env-loader="$(find cob_bringup)/env.sh" default="true" timeout="30"/>
+        <machine name="cob4-2-t1" address="$(arg cob4-2-t1)" env-loader="$(arg env-script)" default="true" timeout="30"/>
 
         <include file="$(find cob_script_server)/launch/script_server.launch"/>
         <include file="$(find cob_bringup)/tools/android.launch">
@@ -200,7 +201,7 @@
     </group>
 
     <group>
-        <machine name="cob4-2-t2" address="$(arg cob4-2-t2)" env-loader="$(find cob_bringup)/env.sh" default="true" timeout="30"/>
+        <machine name="cob4-2-t2" address="$(arg cob4-2-t2)" env-loader="$(arg env-script)" default="true" timeout="30"/>
 
         <include file="$(find cob_bringup)/tools/pc_monitor.launch">
             <arg name="robot" value="$(arg robot)"/>
@@ -230,7 +231,7 @@
     </group>
 
     <group>
-        <machine name="cob4-2-t3" address="$(arg cob4-2-t3)" env-loader="$(find cob_bringup)/env.sh" default="true" timeout="30"/>
+        <machine name="cob4-2-t3" address="$(arg cob4-2-t3)" env-loader="$(arg env-script)" default="true" timeout="30"/>
 
         <include file="$(find cob_bringup)/tools/pc_monitor.launch">
             <arg name="robot" value="$(arg robot)"/>
@@ -260,7 +261,7 @@
     </group>
 
     <group>
-        <machine name="cob4-2-s1" address="$(arg cob4-2-s1)" env-loader="$(find cob_bringup)/env.sh" default="true" timeout="30"/>
+        <machine name="cob4-2-s1" address="$(arg cob4-2-s1)" env-loader="$(arg env-script)" default="true" timeout="30"/>
 
         <include file="$(find cob_bringup)/tools/pc_monitor.launch">
             <arg name="robot" value="$(arg robot)"/>
@@ -283,7 +284,7 @@
     </group>
 
     <group>
-        <machine name="cob4-2-h1" address="$(arg cob4-2-h1)" env-loader="$(find cob_bringup)/env.sh" default="true" timeout="30"/>
+        <machine name="cob4-2-h1" address="$(arg cob4-2-h1)" env-loader="$(arg env-script)" default="true" timeout="30"/>
 
         <include file="$(find cob_bringup)/tools/pc_monitor.launch">
             <arg name="robot" value="$(arg robot)"/>
@@ -309,6 +310,6 @@
         </include>
     </group>
 
-    <machine name="cob4-2-b1" address="$(arg cob4-2-b1)" env-loader="$(find cob_bringup)/env.sh" default="true" timeout="30"/>
+    <machine name="cob4-2-b1" address="$(arg cob4-2-b1)" env-loader="$(arg env-script)" default="true" timeout="30"/>
 
 </launch>

--- a/cob_bringup/robots/cob4-3.launch
+++ b/cob_bringup/robots/cob4-3.launch
@@ -1,8 +1,11 @@
 <?xml version="1.0"?>
 <launch>
 
+	<arg name="env-script" default="$(find cob_bringup)/env.sh"/>
+
 	<include file="$(find cob_bringup)/robots/cob4-3.xml" >
 		<arg name="cob4-3-b1" value="cob4-3-b1"/>
+		<arg name="env-script" value="$(arg env-script)"/>
 	</include>
 
 </launch>

--- a/cob_bringup/robots/cob4-3.xml
+++ b/cob_bringup/robots/cob4-3.xml
@@ -4,7 +4,7 @@
 	<!-- args -->
 	<arg name="robot" value="cob4-3"/>
 	<arg name="cob4-3-b1" default="localhost"/>
-
+	<arg name="env-script" default="$(find cob_bringup)/env.sh"/>
 
 	<!-- upload robot description -->
 	<include file="$(find cob_hardware_config)/common/upload_robot.launch" >
@@ -15,7 +15,7 @@
 	<include file="$(find cob_default_robot_config)/$(arg robot)/upload_param_$(arg robot).launch" />
 
 	<group>
-		<machine name="cob4-3-b1" address="$(arg cob4-3-b1)" env-loader="$(find cob_bringup)/env.sh" default="true"/>
+		<machine name="cob4-3-b1" address="$(arg cob4-3-b1)" env-loader="$(arg env-script)" default="true"/>
 
 		<include file="$(find cob_bringup)/tools/pc_monitor.launch" >
 			<arg name="robot" value="$(arg robot)" />
@@ -57,6 +57,6 @@
 		</include>
 	</group>
 
-	<machine name="cob4-3-b1" address="$(arg cob4-3-b1)" env-loader="$(find cob_bringup)/env.sh" default="true"/>
+	<machine name="cob4-3-b1" address="$(arg cob4-3-b1)" env-loader="$(arg env-script)" default="true"/>
 
 </launch>

--- a/cob_bringup/robots/cob4-4.launch
+++ b/cob_bringup/robots/cob4-4.launch
@@ -1,8 +1,11 @@
 <?xml version="1.0"?>
 <launch>
 
+	<arg name="env-script" default="$(find cob_bringup)/env.sh"/>
+
 	<include file="$(find cob_bringup)/robots/cob4-4.xml" >
 		<arg name="cob4-4-b1" value="cob4-4-b1"/>
+		<arg name="env-script" value="$(arg env-script)"/>
 	</include>
 
 </launch>

--- a/cob_bringup/robots/cob4-4.xml
+++ b/cob_bringup/robots/cob4-4.xml
@@ -4,6 +4,8 @@
 	<!-- args -->
 	<arg name="robot" value="cob4-4"/>
 	<arg name="cob4-4-b1" default="localhost"/>
+	<arg name="env-script" default="$(find cob_bringup)/env.sh"/>
+
 
 
 	<!-- upload robot description -->
@@ -15,7 +17,7 @@
 	<include file="$(find cob_default_robot_config)/$(arg robot)/upload_param_$(arg robot).launch" />
 
 	<group>
-		<machine name="cob4-4-b1" address="$(arg cob4-4-b1)" env-loader="$(find cob_bringup)/env.sh" default="true"/>
+		<machine name="cob4-4-b1" address="$(arg cob4-4-b1)" env-loader="$(arg env-script)" default="true"/>
 
 		<include file="$(find cob_bringup)/tools/pc_monitor.launch" >
 			<arg name="robot" value="$(arg robot)" />
@@ -53,6 +55,6 @@
 		</include>
 	</group>
 
-	<machine name="cob4-4-b1" address="$(arg cob4-4-b1)" env-loader="$(find cob_bringup)/env.sh" default="true"/>
+	<machine name="cob4-4-b1" address="$(arg cob4-4-b1)" env-loader="$(arg env-script)" default="true"/>
 
 </launch>

--- a/cob_bringup/robots/cob4-5.launch
+++ b/cob_bringup/robots/cob4-5.launch
@@ -1,6 +1,8 @@
 <?xml version="1.0"?>
 <launch>
 
+	<arg name="env-script" default="$(find cob_bringup)/env.sh"/>
+
 	<include file="$(find cob_bringup)/robots/cob4-5.xml" >
 		<!-- cob4-5 is currently a special config setup of cob4-5 hardware -->
 		<arg name="cob4-5-b1" value="cob4-5-b1"/>
@@ -9,7 +11,7 @@
 		<arg name="cob4-5-t3" value="cob4-5-t3"/>
 		<arg name="cob4-5-s1" value="cob4-5-s1"/>
 		<arg name="cob4-5-h1" value="cob4-5-h1"/>
-		<arg name="env-script" value="$(find cob_bringup)/env.sh"/>
+		<arg name="env-script" value="$(arg env-script)"/>
 	</include>
 
 </launch>

--- a/cob_bringup/robots/cob4-5.launch
+++ b/cob_bringup/robots/cob4-5.launch
@@ -9,6 +9,7 @@
 		<arg name="cob4-5-t3" value="cob4-5-t3"/>
 		<arg name="cob4-5-s1" value="cob4-5-s1"/>
 		<arg name="cob4-5-h1" value="cob4-5-h1"/>
+		<arg name="env-script" value="$(find cob_bringup)/env.sh"/>
 	</include>
 
 </launch>

--- a/cob_bringup/robots/cob4-5.xml
+++ b/cob_bringup/robots/cob4-5.xml
@@ -9,6 +9,7 @@
     <arg name="cob4-5-t3" default="localhost"/>
     <arg name="cob4-5-s1" default="localhost"/>
     <arg name="cob4-5-h1" default="localhost"/>
+    <arg name="env-script" default="$(find cob_bringup)/env.sh"/>
 
     <!-- upload robot description -->
     <include file="$(find cob_hardware_config)/common/upload_robot.launch">
@@ -19,7 +20,7 @@
     <include file="$(find cob_default_robot_config)/$(arg robot)/upload_param_$(arg robot).launch"/>
 
     <group>
-        <machine name="cob4-5-b1" address="$(arg cob4-5-b1)" env-loader="$(find cob_bringup)/env.sh" default="true" timeout="30"/>
+        <machine name="cob4-5-b1" address="$(arg cob4-5-b1)" env-loader="$(arg env-script)" default="true" timeout="30"/>
 
         <include file="$(find cob_bringup)/tools/pc_monitor.launch">
             <arg name="robot" value="$(arg robot)"/>
@@ -88,7 +89,7 @@
     </group>
 
     <group>
-        <machine name="cob4-5-t1" address="$(arg cob4-5-t1)" env-loader="$(find cob_bringup)/env.sh" default="true" timeout="30"/>
+        <machine name="cob4-5-t1" address="$(arg cob4-5-t1)" env-loader="$(arg env-script)" default="true" timeout="30"/>
 
         <include file="$(find cob_script_server)/launch/script_server.launch"/>
         <include file="$(find cob_bringup)/tools/behavior.launch">
@@ -141,7 +142,7 @@
     </group>
 
     <group>
-        <machine name="cob4-5-t2" address="$(arg cob4-5-t2)" env-loader="$(find cob_bringup)/env.sh" default="true" timeout="30"/>
+        <machine name="cob4-5-t2" address="$(arg cob4-5-t2)" env-loader="$(arg env-script)" default="true" timeout="30"/>
 
         <include file="$(find cob_bringup)/tools/pc_monitor.launch">
             <arg name="robot" value="$(arg robot)"/>
@@ -163,7 +164,7 @@
     </group>
 
     <group>
-        <machine name="cob4-5-t3" address="$(arg cob4-5-t3)" env-loader="$(find cob_bringup)/env.sh" default="true" timeout="30"/>
+        <machine name="cob4-5-t3" address="$(arg cob4-5-t3)" env-loader="$(arg env-script)" default="true" timeout="30"/>
 
         <include file="$(find cob_bringup)/tools/pc_monitor.launch">
             <arg name="robot" value="$(arg robot)"/>
@@ -199,7 +200,7 @@
     </group>
 
     <group>
-        <machine name="cob4-5-s1" address="$(arg cob4-5-s1)" env-loader="$(find cob_bringup)/env.sh" default="true" timeout="30"/>
+        <machine name="cob4-5-s1" address="$(arg cob4-5-s1)" env-loader="$(arg env-script)" default="true" timeout="30"/>
 
         <include file="$(find cob_bringup)/tools/pc_monitor.launch">
             <arg name="robot" value="$(arg robot)"/>
@@ -223,7 +224,7 @@
     </group>
 
     <group>
-        <machine name="cob4-5-h1" address="$(arg cob4-5-h1)" env-loader="$(find cob_bringup)/env.sh" default="true" timeout="30"/>
+        <machine name="cob4-5-h1" address="$(arg cob4-5-h1)" env-loader="$(arg env-script)" default="true" timeout="30"/>
 
         <include file="$(find cob_bringup)/tools/pc_monitor.launch">
             <arg name="robot" value="$(arg robot)"/>
@@ -238,6 +239,6 @@
 
     </group>
 
-    <machine name="cob4-5-b1" address="$(arg cob4-5-b1)" env-loader="$(find cob_bringup)/env.sh" default="true" timeout="30"/>
+    <machine name="cob4-5-b1" address="$(arg cob4-5-b1)" env-loader="$(arg env-script)" default="true" timeout="30"/>
 
 </launch>

--- a/cob_bringup/robots/cob4-6.launch
+++ b/cob_bringup/robots/cob4-6.launch
@@ -1,8 +1,10 @@
 <?xml version="1.0"?>
 <launch>
+	<arg name="env-script" default="$(find cob_bringup)/env.sh"/>
 
 	<include file="$(find cob_bringup)/robots/cob4-6.xml" >
 		<arg name="cob4-6-b1" value="cob4-6-b1"/>
+		<arg name="env-script" value="$(arg env-script)"/>
 	</include>
 
 </launch>

--- a/cob_bringup/robots/cob4-6.xml
+++ b/cob_bringup/robots/cob4-6.xml
@@ -4,6 +4,7 @@
 	<!-- args -->
 	<arg name="robot" value="cob4-6"/>
 	<arg name="cob4-6-b1" default="localhost"/>
+	<arg name="env-script" default="$(find cob_bringup)/env.sh"/>
 
 
 	<!-- upload robot description -->
@@ -15,7 +16,7 @@
 	<include file="$(find cob_default_robot_config)/$(arg robot)/upload_param_$(arg robot).launch" />
 
 	<group>
-		<machine name="cob4-6-b1" address="$(arg cob4-6-b1)" env-loader="$(find cob_bringup)/env.sh" default="true"/>
+		<machine name="cob4-6-b1" address="$(arg cob4-6-b1)" env-loader="$(arg env-script)" default="true"/>
 
 		<include file="$(find cob_bringup)/tools/pc_monitor.launch" >
 			<arg name="robot" value="$(arg robot)" />
@@ -53,6 +54,6 @@
 		</include>
 	</group>
 
-	<machine name="cob4-6-b1" address="$(arg cob4-6-b1)" env-loader="$(find cob_bringup)/env.sh" default="true"/>
+	<machine name="cob4-6-b1" address="$(arg cob4-6-b1)" env-loader="$(arg env-script)" default="true"/>
 
 </launch>

--- a/cob_bringup/robots/raw3-1.launch
+++ b/cob_bringup/robots/raw3-1.launch
@@ -1,11 +1,14 @@
 <?xml version="1.0"?>
 <launch>
 
+	<arg name="env-script" default="$(find cob_bringup)/env.sh"/>
+
 	<include file="$(find cob_bringup)/robots/raw3-1.xml" >
 		<arg name="pc1" value="raw3-1-pc1"/>
 		<arg name="pc2" value="raw3-1-pc2"/>
 		<arg name="pc3" value="raw3-1-pc3"/>
 		<arg name="ur_ip" value="192.168.141.40"/>
+		<arg name="env-script" value="$(arg env-script)"/>
 	</include>
 
 </launch>

--- a/cob_bringup/robots/raw3-1.xml
+++ b/cob_bringup/robots/raw3-1.xml
@@ -7,6 +7,8 @@
 	<arg name="pc2" default="localhost"/>
 	<arg name="pc3" default="localhost"/>
 	<arg name="ur_ip" default="localhost" />
+	<arg name="env-script" default="$(find cob_bringup)/env.sh"/>
+
 
 	<!-- upload robot description -->
 	<include file="$(find cob_hardware_config)/common/upload_robot.launch" >
@@ -17,7 +19,7 @@
 	<include file="$(find cob_default_robot_config)/raw3-1/upload_param_raw3-1.launch" />
 
 	<group>
-		<machine name="pc1" address="$(arg pc1)" env-loader="$(find cob_bringup)/env.sh" default="true"/>
+		<machine name="pc1" address="$(arg pc1)" env-loader="$(arg env-script)" default="true"/>
 
 		<!-- pc monitor -->
 		<include file="$(find cob_bringup)/tools/pc_monitor.launch" >
@@ -105,7 +107,7 @@
 	</group>
 
 	<group>
-		<machine name="pc2" address="$(arg pc2)" env-loader="$(find cob_bringup)/env.sh" default="true"/>
+		<machine name="pc2" address="$(arg pc2)" env-loader="$(arg env-script)" default="true"/>
 
 		<!-- pc monitor -->
 		<include file="$(find cob_bringup)/tools/pc_monitor.launch" >
@@ -118,6 +120,6 @@
 		</include>
 	</group>
 
-	<machine name="pc1" address="$(arg pc1)" env-loader="$(find cob_bringup)/env.sh" default="true"/>
+	<machine name="pc1" address="$(arg pc1)" env-loader="$(arg env-script)" default="true"/>
 
 </launch>

--- a/cob_bringup/robots/raw3-2.launch
+++ b/cob_bringup/robots/raw3-2.launch
@@ -1,8 +1,11 @@
 <?xml version="1.0"?>
 <launch>
 
+	<arg name="env-script" default="$(find cob_bringup)/env.sh"/>
+
 	<include file="$(find cob_bringup)/robots/raw3-2.xml" >
 		<arg name="pc1" value="raw3-2-pc1"/>
+		<arg name="env-script" value="$(arg env-script)"/>
 	</include>
 
 </launch>

--- a/cob_bringup/robots/raw3-2.xml
+++ b/cob_bringup/robots/raw3-2.xml
@@ -4,6 +4,7 @@
 	<!-- args -->
 	<arg name="robot" value="raw3-2"/>
 	<arg name="pc1" default="localhost"/>
+	<arg name="env-script" default="$(find cob_bringup)/env.sh"/>
 
 	<!-- upload robot description -->
 	<include file="$(find cob_hardware_config)/common/upload_robot.launch" >
@@ -14,7 +15,7 @@
 	<include file="$(find cob_default_robot_config)/raw3-2/upload_param_raw3-2.launch" />
 
 	<group>
-		<machine name="pc1" address="$(arg pc1)" env-loader="$(find cob_bringup)/env.sh" default="true"/>
+		<machine name="pc1" address="$(arg pc1)" env-loader="$(arg env-script)" default="true"/>
 
 		<include file="$(find cob_bringup)/tools/pc_monitor.launch" >
 			<arg name="robot" value="$(arg robot)" />
@@ -68,6 +69,6 @@
 		<include file="$(find cob_script_server)/launch/script_server.launch" />
 	</group>
 
-	<machine name="pc1" address="$(arg pc1)" env-loader="$(find cob_bringup)/env.sh" default="true"/>
+	<machine name="pc1" address="$(arg pc1)" env-loader="$(arg env-script)" default="true"/>
 
 </launch>

--- a/cob_bringup/robots/raw3-3.launch
+++ b/cob_bringup/robots/raw3-3.launch
@@ -1,10 +1,13 @@
 <?xml version="1.0"?>
 <launch>
 
+	<arg name="env-script" default="$(find cob_bringup)/env.sh"/>
+
 	<include file="$(find cob_bringup)/robots/raw3-3.xml" >
 		<arg name="pc1" value="raw3-3-pc1"/>
 		<arg name="pc2" value="raw3-3-pc2"/>
 		<arg name="pc3" value="raw3-3-pc3"/>
+		<arg name="env-script" value="$(arg env-script)"/>
 	</include>
 
 </launch>

--- a/cob_bringup/robots/raw3-3.xml
+++ b/cob_bringup/robots/raw3-3.xml
@@ -7,6 +7,8 @@
 	<arg name="pc1" default="localhost"/>
 	<arg name="pc2" default="localhost"/>
 	<arg name="pc3" default="localhost"/>
+	<arg name="env-script" default="$(find cob_bringup)/env.sh"/>
+
 
 	<!-- upload robot description -->
 	<include file="$(find cob_hardware_config)/common/upload_robot.launch" >
@@ -17,7 +19,7 @@
 	<include file="$(find cob_default_robot_config)/raw3-3/upload_param_raw3-3.launch" />
 
 	<group>
-		<machine name="pc1" address="$(arg pc1)" env-loader="$(find cob_bringup)/env.sh" default="true"/>
+		<machine name="pc1" address="$(arg pc1)" env-loader="$(arg env-script)" default="true"/>
 
 		<!-- startup hardware -->
 		<include file="$(find cob_bringup)/drivers/base_driver.launch" >
@@ -102,7 +104,7 @@
 	</group>
 
 	<group>
-		<machine name="pc2" address="$(arg pc2)" env-loader="$(find cob_bringup)/env.sh" default="true"/>
+		<machine name="pc2" address="$(arg pc2)" env-loader="$(arg env-script)" default="true"/>
 
 		<include file="$(find cob_bringup)/tools/pc_monitor.launch" >
 			<arg name="robot" value="$(arg robot)" />
@@ -114,6 +116,6 @@
 		</include>
 	</group>
 
-	<machine name="pc1" address="$(arg pc1)" env-loader="$(find cob_bringup)/env.sh" default="true"/>
+	<machine name="pc1" address="$(arg pc1)" env-loader="$(arg env-script)" default="true"/>
 
 </launch>

--- a/cob_bringup/robots/raw3-4.launch
+++ b/cob_bringup/robots/raw3-4.launch
@@ -1,11 +1,14 @@
 <?xml version="1.0"?>
 <launch>
 
+	<arg name="env-script" default="$(find cob_bringup)/env.sh"/>
+
 	<include file="$(find cob_bringup)/robots/raw3-4.xml" >
 		<arg name="pc1" value="raw3-4-pc1"/>
 		<arg name="pc2" value="raw3-4-pc2"/>
 		<arg name="pc3" value="raw3-4-pc3"/>
 		<arg name="ur_ip" value="192.168.44.51"/>
+		<arg name="env-script" value="$(arg env-script)"/>
 	</include>
 
 </launch>

--- a/cob_bringup/robots/raw3-4.xml
+++ b/cob_bringup/robots/raw3-4.xml
@@ -7,6 +7,7 @@
 	<arg name="pc2" default="localhost"/>
 	<arg name="pc3" default="localhost"/>
 	<arg name="ur_ip" default="localhost"/>
+	<arg name="env-script" default="$(find cob_bringup)/env.sh"/>
 
 	<!-- upload robot description -->
 	<include file="$(find cob_hardware_config)/common/upload_robot.launch" >
@@ -17,7 +18,7 @@
 	<include file="$(find cob_default_robot_config)/raw3-4/upload_param_raw3-4.launch" />
 
 	<group>
-		<machine name="pc1" address="$(arg pc1)" env-loader="$(find cob_bringup)/env.sh" default="true"/>
+		<machine name="pc1" address="$(arg pc1)" env-loader="$(arg env-script)" default="true"/>
 
 		<include file="$(find cob_bringup)/tools/pc_monitor.launch" >
 			<arg name="robot" value="$(arg robot)" />
@@ -78,7 +79,7 @@
 	</group>
 
 	<group>
-		<machine name="pc2" address="$(arg pc2)" env-loader="$(find cob_bringup)/env.sh" default="true"/>
+		<machine name="pc2" address="$(arg pc2)" env-loader="$(arg env-script)" default="true"/>
 
 		<include file="$(find cob_bringup)/tools/pc_monitor.launch" >
 			<arg name="robot" value="$(arg robot)" />
@@ -106,6 +107,6 @@
 		</include>
 	</group>
 
-	<machine name="pc1" address="$(arg pc1)" env-loader="$(find cob_bringup)/env.sh" default="true"/>
+	<machine name="pc1" address="$(arg pc1)" env-loader="$(arg env-script)" default="true"/>
 
 </launch>

--- a/cob_bringup/robots/raw3-5.launch
+++ b/cob_bringup/robots/raw3-5.launch
@@ -1,8 +1,11 @@
 <?xml version="1.0"?>
 <launch>
 
+	<arg name="env-script" default="$(find cob_bringup)/env.sh"/>
+
 	<include file="$(find cob_bringup)/robots/raw3-5.xml" >
 		<arg name="pc1" value="i60sr2"/>
+		<arg name="env-script" value="$(arg env-script)"/>
 	</include>
 
 </launch>

--- a/cob_bringup/robots/raw3-5.xml
+++ b/cob_bringup/robots/raw3-5.xml
@@ -4,6 +4,7 @@
 	<!-- args -->
 	<arg name="robot" value="raw3-5"/>
 	<arg name="pc1" default="localhost"/>
+	<arg name="env-script" default="$(find cob_bringup)/env.sh"/>
 
 	<!-- upload robot description -->
 	<include file="$(find cob_hardware_config)/common/upload_robot.launch" >
@@ -14,7 +15,7 @@
 	<include file="$(find cob_default_robot_config)/raw3-5/upload_param_raw3-5.launch" />
 
 	<group>
-		<machine name="pc1" address="$(arg pc1)" env-loader="$(find cob_bringup)/env.sh" default="true"/>
+		<machine name="pc1" address="$(arg pc1)" env-loader="$(arg env-script)" default="true"/>
 
 		<include file="$(find cob_bringup)/tools/pc_monitor.launch" >
 			<arg name="robot" value="$(arg robot)" />
@@ -45,10 +46,10 @@
 		</include>
 
 		<!--<include file="$(find cob_bringup)/tools/battery_monitor.launch" >
-		    <arg name="robot" value="$(arg robot)" />
+			<arg name="robot" value="$(arg robot)" />
 		</include>-->
 		<include file="$(find cob_bringup)/tools/emergency_stop_monitor.launch" >
-		    <arg name="robot" value="$(arg robot)" />
+			<arg name="robot" value="$(arg robot)" />
 		</include>
 
 		<include file="$(find cob_bringup)/drivers/base_driver.launch" >
@@ -78,6 +79,6 @@
 		<include file="$(find cob_script_server)/launch/script_server.launch" />
 	</group>
 
-	<machine name="pc1" address="$(arg pc1)" env-loader="$(find cob_bringup)/env.sh" default="true"/>
+	<machine name="pc1" address="$(arg pc1)" env-loader="$(arg env-script)" default="true"/>
 
 </launch>

--- a/cob_bringup/robots/raw3-6.launch
+++ b/cob_bringup/robots/raw3-6.launch
@@ -1,8 +1,11 @@
 <?xml version="1.0"?>
 <launch>
 
+	<arg name="env-script" default="$(find cob_bringup)/env.sh"/>
+
 	<include file="$(find cob_bringup)/robots/raw3-6.xml" >
 		<arg name="pc1" value="raw3-6-pc1"/>
+		<arg name="env-script" value="$(arg env-script)"/>
 	</include>
 
 </launch>

--- a/cob_bringup/robots/raw3-6.xml
+++ b/cob_bringup/robots/raw3-6.xml
@@ -4,6 +4,7 @@
 	<!-- args -->
 	<arg name="robot" value="raw3-6"/>
 	<arg name="pc1" default="localhost"/>
+	<arg name="env-script" default="$(find cob_bringup)/env.sh"/>
 
 	<!-- upload robot description -->
 	<include file="$(find cob_hardware_config)/common/upload_robot.launch" >
@@ -14,7 +15,7 @@
 	<include file="$(find cob_default_robot_config)/raw3-6/upload_param_raw3-6.launch" />
 
 	<group>
-		<machine name="pc1" address="$(arg pc1)" env-loader="$(find cob_bringup)/env.sh" default="true"/>
+		<machine name="pc1" address="$(arg pc1)" env-loader="$(arg env-script)" default="true"/>
 
 		<include file="$(find cob_bringup)/tools/pc_monitor.launch" >
 			<arg name="robot" value="$(arg robot)" />
@@ -27,11 +28,11 @@
 		<!-- startup hardware -->
 		<!-- lower robot -->
 		<include file="$(find cob_bringup)/drivers/base_driver.launch" >
-                        <arg name="robot" value="$(arg robot)" />
-                </include>
-                <include file="$(find cob_bringup)/controllers/base_controller.launch" >
-                        <arg name="robot" value="$(arg robot)" />
-                </include>
+			<arg name="robot" value="$(arg robot)" />
+		</include>
+		<include file="$(find cob_bringup)/controllers/base_controller.launch" >
+			<arg name="robot" value="$(arg robot)" />
+		</include>
 		<include file="$(find cob_bringup)/drivers/sick_s300.launch" >
 			<arg name="robot" value="$(arg robot)" />
 			<arg name="name" value="base_laser_front" />
@@ -44,21 +45,21 @@
 			<arg name="robot" value="$(arg robot)" />
 		</include>
 
-                <include file="$(find cob_bringup)/drivers/phidgets.launch" >
-                        <arg name="robot" value="$(arg robot)" />
-                </include>
+		<include file="$(find cob_bringup)/drivers/phidgets.launch" >
+			<arg name="robot" value="$(arg robot)" />
+		</include>
 
-                <include file="$(find cob_bringup)/drivers/powerstate_phidget.launch">
-                        <arg name="robot" value="$(arg robot)"/>
-                </include>
+		<include file="$(find cob_bringup)/drivers/powerstate_phidget.launch">
+			<arg name="robot" value="$(arg robot)"/>
+		</include>
 
-                <include file="$(find cob_bringup)/drivers/emstate_phidget.launch">
-                        <arg name="robot" value="$(arg robot)"/>
-                </include>
+		<include file="$(find cob_bringup)/drivers/emstate_phidget.launch">
+			<arg name="robot" value="$(arg robot)"/>
+		</include>
 
-                <include file="$(find cob_bringup)/tools/battery_monitor.launch" >
-                        <arg name="robot" value="$(arg robot)" />
-                </include>
+		<include file="$(find cob_bringup)/tools/battery_monitor.launch" >
+			<arg name="robot" value="$(arg robot)" />
+		</include>
 
 		<!-- upper robot -->
 
@@ -73,8 +74,8 @@
 			<arg name="robot" value="$(arg robot)" />
 		</include>
 		<include file="$(find cob_bringup)/tools/emergency_stop_monitor.launch" >
-                        <arg name="robot" value="$(arg robot)" />
-                </include>
+			<arg name="robot" value="$(arg robot)" />
+		</include>
 
 		<!-- aggregated robot_state_publisher -->
 		<include file="$(find cob_bringup)/tools/robot_state_publisher.launch">
@@ -85,6 +86,6 @@
 		<include file="$(find cob_script_server)/launch/script_server.launch" />
 	</group>
 
-	<machine name="pc1" address="$(arg pc1)" env-loader="$(find cob_bringup)/env.sh" default="true"/>
+	<machine name="pc1" address="$(arg pc1)" env-loader="$(arg env-script)" default="true"/>
 
 </launch>


### PR DESCRIPTION
It is the same concept as https://github.com/ipa320/cob_robots/pull/462/files (thanks @ipa-fxm)

It is needed in case that you try to launch drivers on a remote machine sourcing a different workspace. For example if logged as nhg user I source `/u/otherUsergit/care-o-bot/devel/setup.bash` , and I command `roslaunch cob_bringup robot.launch` the machine tag will find my env.sh https://github.com/ipa320/cob_robots/blob/indigo_dev/cob_bringup/env.sh and will set `MY_CATKIN_WORKSPACE` to `/u/nhg/git/care-o-bot/devel` ignoring the launch file the setup.bash that I sourced. 

If the user is able to set the env.sh path I can command `roslaunch cob_bringup cob4-1.launch env-script=/u/otherUsergit/care-o-bot/devel/env.sh` and I will run the packages from `/u/otherUsergit/care-o-bot/devel` wokspace.
