### PR TITLE
Separate sensors actors

### DIFF
--- a/cob_hardware_config/cob4-1/urdf/cob4-1.urdf.xacro
+++ b/cob_hardware_config/cob4-1/urdf/cob4-1.urdf.xacro
@@ -22,6 +22,7 @@
 
   <!-- sensorring -->
   <xacro:include filename="$(find cob_description)/urdf/cob4_sensorring/sensorring_asus.urdf.xacro" />
+  <xacro:include filename="$(find cob_description)/urdf/sensors/kinect.urdf.xacro" />
 
   <!-- composition of the robot -->
   <xacro:base name="base" use_old_joint_names="false"/>
@@ -58,6 +59,9 @@
   <xacro:sensorring name="sensorring" parent="head_3_link">
     <origin xyz="${sensorring_x} ${sensorring_y} ${sensorring_z}" rpy="${sensorring_roll} ${sensorring_pitch} ${sensorring_yaw}" />
   </xacro:sensorring>
+  <xacro:cob_kinect_v0 name="sensorring_cam3d" ros_topic="sensorring_cam3d" parent="sensorring_link">
+    <origin xyz="${sensorring_cam3d_x} ${sensorring_cam3d_y} ${sensorring_cam3d_z}" rpy="${sensorring_cam3d_roll} ${sensorring_cam3d_pitch} ${sensorring_cam3d_yaw}" />
+  </xacro:cob_kinect_v0>
   <gazebo>
     <plugin name="ros_control" filename="libhwi_switch_gazebo_ros_control.so">
       <robotNamespace>sensorring</robotNamespace>

--- a/cob_hardware_config/cob4-1/urdf/cob4-1.urdf.xacro
+++ b/cob_hardware_config/cob4-1/urdf/cob4-1.urdf.xacro
@@ -14,7 +14,7 @@
   <xacro:include filename="$(find cob_description)/urdf/cob4_base/base.urdf.xacro" />
 
   <!-- torso -->
-  <xacro:include filename="$(find cob_description)/urdf/cob4_torso/torso_2dof.urdf.xacro" />
+  <xacro:include filename="$(find cob_description)/urdf/cob4_torso/torso.urdf.xacro" />
 
   <!-- head -->
   <xacro:include filename="$(find cob_description)/urdf/cob4_head/head.urdf.xacro" />
@@ -36,7 +36,7 @@
     </plugin>
   </gazebo>
 
-  <xacro:torso name="torso" parent="base_link">
+  <xacro:torso name="torso" parent="base_link" dof1="false" dof2="true" dof3="true">
     <origin xyz="${torso_x} ${torso_y} ${torso_z}" rpy="${torso_roll} ${torso_pitch} ${torso_yaw}" />
   </xacro:torso>
   <!-- left camera -->

--- a/cob_hardware_config/cob4-1/urdf/cob4-1.urdf.xacro
+++ b/cob_hardware_config/cob4-1/urdf/cob4-1.urdf.xacro
@@ -18,6 +18,7 @@
 
   <!-- head -->
   <xacro:include filename="$(find cob_description)/urdf/cob4_head/head.urdf.xacro" />
+  <xacro:include filename="$(find cob_description)/urdf/sensors/usb_cam.urdf.xacro" />
 
   <!-- sensorring -->
   <xacro:include filename="$(find cob_description)/urdf/cob4_sensorring/sensorring_asus.urdf.xacro" />
@@ -44,6 +45,9 @@
   <xacro:head name="head" parent="torso_3_link">
     <origin xyz="${head_x} ${head_y} ${head_z}" rpy="${head_roll} ${head_pitch} ${head_yaw}" />
   </xacro:head>
+  <xacro:usb_cam name="head_cam" parent="head_3_link" ros_topic="head_cam">
+    <origin xyz="${head_cam_x} ${head_cam_y} ${head_cam_z}" rpy="${head_cam_roll} ${head_cam_pitch} ${head_cam_yaw}" />
+  </xacro:usb_cam>
   <gazebo>
     <plugin name="ros_control" filename="libhwi_switch_gazebo_ros_control.so">
       <robotNamespace>head</robotNamespace>

--- a/cob_hardware_config/cob4-1/urdf/cob4-1.urdf.xacro
+++ b/cob_hardware_config/cob4-1/urdf/cob4-1.urdf.xacro
@@ -42,7 +42,7 @@
     </plugin>
   </gazebo>
 
-  <xacro:head name="head" parent="torso_3_link">
+  <xacro:head name="head" parent="torso_3_link" dof1="true" dof2="true" dof3="true">
     <origin xyz="${head_x} ${head_y} ${head_z}" rpy="${head_roll} ${head_pitch} ${head_yaw}" />
   </xacro:head>
   <xacro:usb_cam name="head_cam" parent="head_3_link" ros_topic="head_cam">

--- a/cob_hardware_config/cob4-1/urdf/cob4-1.urdf.xacro
+++ b/cob_hardware_config/cob4-1/urdf/cob4-1.urdf.xacro
@@ -18,11 +18,14 @@
 
   <!-- head -->
   <xacro:include filename="$(find cob_description)/urdf/cob4_head/head.urdf.xacro" />
-  <xacro:include filename="$(find cob_description)/urdf/sensors/usb_cam.urdf.xacro" />
 
   <!-- sensorring -->
   <xacro:include filename="$(find cob_description)/urdf/cob4_sensorring/sensorring.urdf.xacro" />
+
+  <!-- sensors -->
+  <xacro:include filename="$(find cob_description)/urdf/sensors/realsense.urdf.xacro" />
   <xacro:include filename="$(find cob_description)/urdf/sensors/kinect.urdf.xacro" />
+  <xacro:include filename="$(find cob_description)/urdf/sensors/usb_cam.urdf.xacro" />
 
   <!-- composition of the robot -->
   <xacro:base name="base" use_old_joint_names="false"/>
@@ -36,6 +39,18 @@
   <xacro:torso name="torso" parent="base_link">
     <origin xyz="${torso_x} ${torso_y} ${torso_z}" rpy="${torso_roll} ${torso_pitch} ${torso_yaw}" />
   </xacro:torso>
+  <!-- left camera -->
+  <xacro:cob_kinect_v0 name="torso_cam3d_left" ros_topic="torso_cam3d_left" parent="torso_3_link">
+    <origin xyz="${torso_cam3d_left_x} ${torso_cam3d_left_y} ${torso_cam3d_left_z}" rpy="${torso_cam3d_left_roll} ${torso_cam3d_left_pitch} ${torso_cam3d_left_yaw}" />
+  </xacro:cob_kinect_v0>
+  <!-- right camera -->
+  <xacro:cob_kinect_v0 name="torso_cam3d_right" ros_topic="torso_cam3d_right" parent="torso_3_link">
+    <origin xyz="${torso_cam3d_right_x} ${torso_cam3d_right_y} ${torso_cam3d_right_z}" rpy="${torso_cam3d_right_roll} ${torso_cam3d_right_pitch} ${torso_cam3d_right_yaw}" />
+  </xacro:cob_kinect_v0>
+  <!-- down camera -->
+  <xacro:realsense name="torso_cam3d_down" ros_topic="torso_cam3d_down" parent="torso_3_link">
+    <origin xyz="${torso_cam3d_down_x} ${torso_cam3d_down_y} ${torso_cam3d_down_z}" rpy="${torso_cam3d_down_roll} ${torso_cam3d_down_pitch} ${torso_cam3d_down_yaw}" />
+  </xacro:realsense>
   <gazebo>
     <plugin name="ros_control" filename="libhwi_switch_gazebo_ros_control.so">
       <robotNamespace>torso</robotNamespace>

--- a/cob_hardware_config/cob4-1/urdf/cob4-1.urdf.xacro
+++ b/cob_hardware_config/cob4-1/urdf/cob4-1.urdf.xacro
@@ -21,7 +21,7 @@
   <xacro:include filename="$(find cob_description)/urdf/sensors/usb_cam.urdf.xacro" />
 
   <!-- sensorring -->
-  <xacro:include filename="$(find cob_description)/urdf/cob4_sensorring/sensorring_asus.urdf.xacro" />
+  <xacro:include filename="$(find cob_description)/urdf/cob4_sensorring/sensorring.urdf.xacro" />
   <xacro:include filename="$(find cob_description)/urdf/sensors/kinect.urdf.xacro" />
 
   <!-- composition of the robot -->

--- a/cob_hardware_config/cob4-10/urdf/cob4-10.urdf.xacro
+++ b/cob_hardware_config/cob4-10/urdf/cob4-10.urdf.xacro
@@ -22,6 +22,7 @@
 
   <!-- sensorring -->
   <xacro:include filename="$(find cob_description)/urdf/cob4_sensorring/sensorring_asus.urdf.xacro" />
+  <xacro:include filename="$(find cob_description)/urdf/sensors/kinect.urdf.xacro" />
 
   <!-- composition of the robot -->
   <xacro:base name="base" use_old_joint_names="false"/>
@@ -58,6 +59,9 @@
   <xacro:sensorring name="sensorring" parent="head_3_link">
     <origin xyz="${sensorring_x} ${sensorring_y} ${sensorring_z}" rpy="${sensorring_roll} ${sensorring_pitch} ${sensorring_yaw}" />
   </xacro:sensorring>
+  <xacro:cob_kinect_v0 name="sensorring_cam3d" ros_topic="sensorring_cam3d" parent="sensorring_link">
+    <origin xyz="${sensorring_cam3d_x} ${sensorring_cam3d_y} ${sensorring_cam3d_z}" rpy="${sensorring_cam3d_roll} ${sensorring_cam3d_pitch} ${sensorring_cam3d_yaw}" />
+  </xacro:cob_kinect_v0>
   <gazebo>
     <plugin name="ros_control" filename="libhwi_switch_gazebo_ros_control.so">
       <robotNamespace>sensorring</robotNamespace>

--- a/cob_hardware_config/cob4-10/urdf/cob4-10.urdf.xacro
+++ b/cob_hardware_config/cob4-10/urdf/cob4-10.urdf.xacro
@@ -14,7 +14,7 @@
   <xacro:include filename="$(find cob_description)/urdf/cob4_base/base.urdf.xacro" />
 
   <!-- torso -->
-  <xacro:include filename="$(find cob_description)/urdf/cob4_torso/torso_2dof.urdf.xacro" />
+  <xacro:include filename="$(find cob_description)/urdf/cob4_torso/torso.urdf.xacro" />
 
   <!-- head -->
   <xacro:include filename="$(find cob_description)/urdf/cob4_head/head.urdf.xacro" />
@@ -36,7 +36,7 @@
     </plugin>
   </gazebo>
 
-  <xacro:torso name="torso" parent="base_link">
+  <xacro:torso name="torso" parent="base_link" dof1="false" dof2="true" dof3="true">
     <origin xyz="${torso_x} ${torso_y} ${torso_z}" rpy="${torso_roll} ${torso_pitch} ${torso_yaw}" />
   </xacro:torso>
   <!-- left camera -->

--- a/cob_hardware_config/cob4-10/urdf/cob4-10.urdf.xacro
+++ b/cob_hardware_config/cob4-10/urdf/cob4-10.urdf.xacro
@@ -18,6 +18,7 @@
 
   <!-- head -->
   <xacro:include filename="$(find cob_description)/urdf/cob4_head/head.urdf.xacro" />
+  <xacro:include filename="$(find cob_description)/urdf/sensors/usb_cam.urdf.xacro" />
 
   <!-- sensorring -->
   <xacro:include filename="$(find cob_description)/urdf/cob4_sensorring/sensorring_asus.urdf.xacro" />
@@ -44,6 +45,9 @@
   <xacro:head name="head" parent="torso_3_link">
     <origin xyz="${head_x} ${head_y} ${head_z}" rpy="${head_roll} ${head_pitch} ${head_yaw}" />
   </xacro:head>
+  <xacro:usb_cam name="head_cam" parent="head_3_link" ros_topic="head_cam">
+    <origin xyz="${head_cam_x} ${head_cam_y} ${head_cam_z}" rpy="${head_cam_roll} ${head_cam_pitch} ${head_cam_yaw}" />
+  </xacro:usb_cam>
   <gazebo>
     <plugin name="ros_control" filename="libhwi_switch_gazebo_ros_control.so">
       <robotNamespace>head</robotNamespace>

--- a/cob_hardware_config/cob4-10/urdf/cob4-10.urdf.xacro
+++ b/cob_hardware_config/cob4-10/urdf/cob4-10.urdf.xacro
@@ -42,7 +42,7 @@
     </plugin>
   </gazebo>
 
-  <xacro:head name="head" parent="torso_3_link">
+  <xacro:head name="head" parent="torso_3_link" dof1="true" dof2="true" dof3="true">
     <origin xyz="${head_x} ${head_y} ${head_z}" rpy="${head_roll} ${head_pitch} ${head_yaw}" />
   </xacro:head>
   <xacro:usb_cam name="head_cam" parent="head_3_link" ros_topic="head_cam">

--- a/cob_hardware_config/cob4-10/urdf/cob4-10.urdf.xacro
+++ b/cob_hardware_config/cob4-10/urdf/cob4-10.urdf.xacro
@@ -18,11 +18,14 @@
 
   <!-- head -->
   <xacro:include filename="$(find cob_description)/urdf/cob4_head/head.urdf.xacro" />
-  <xacro:include filename="$(find cob_description)/urdf/sensors/usb_cam.urdf.xacro" />
 
   <!-- sensorring -->
   <xacro:include filename="$(find cob_description)/urdf/cob4_sensorring/sensorring.urdf.xacro" />
+
+  <!-- sensors -->
+  <xacro:include filename="$(find cob_description)/urdf/sensors/realsense.urdf.xacro" />
   <xacro:include filename="$(find cob_description)/urdf/sensors/kinect.urdf.xacro" />
+  <xacro:include filename="$(find cob_description)/urdf/sensors/usb_cam.urdf.xacro" />
 
   <!-- composition of the robot -->
   <xacro:base name="base" use_old_joint_names="false"/>
@@ -36,6 +39,18 @@
   <xacro:torso name="torso" parent="base_link">
     <origin xyz="${torso_x} ${torso_y} ${torso_z}" rpy="${torso_roll} ${torso_pitch} ${torso_yaw}" />
   </xacro:torso>
+  <!-- left camera -->
+  <xacro:cob_kinect_v0 name="torso_cam3d_left" ros_topic="torso_cam3d_left" parent="torso_3_link">
+    <origin xyz="${torso_cam3d_left_x} ${torso_cam3d_left_y} ${torso_cam3d_left_z}" rpy="${torso_cam3d_left_roll} ${torso_cam3d_left_pitch} ${torso_cam3d_left_yaw}" />
+  </xacro:cob_kinect_v0>
+  <!-- right camera -->
+  <xacro:cob_kinect_v0 name="torso_cam3d_right" ros_topic="torso_cam3d_right" parent="torso_3_link">
+    <origin xyz="${torso_cam3d_right_x} ${torso_cam3d_right_y} ${torso_cam3d_right_z}" rpy="${torso_cam3d_right_roll} ${torso_cam3d_right_pitch} ${torso_cam3d_right_yaw}" />
+  </xacro:cob_kinect_v0>
+  <!-- down camera -->
+  <xacro:realsense name="torso_cam3d_down" ros_topic="torso_cam3d_down" parent="torso_3_link">
+    <origin xyz="${torso_cam3d_down_x} ${torso_cam3d_down_y} ${torso_cam3d_down_z}" rpy="${torso_cam3d_down_roll} ${torso_cam3d_down_pitch} ${torso_cam3d_down_yaw}" />
+  </xacro:realsense>
   <gazebo>
     <plugin name="ros_control" filename="libhwi_switch_gazebo_ros_control.so">
       <robotNamespace>torso</robotNamespace>

--- a/cob_hardware_config/cob4-10/urdf/cob4-10.urdf.xacro
+++ b/cob_hardware_config/cob4-10/urdf/cob4-10.urdf.xacro
@@ -21,7 +21,7 @@
   <xacro:include filename="$(find cob_description)/urdf/sensors/usb_cam.urdf.xacro" />
 
   <!-- sensorring -->
-  <xacro:include filename="$(find cob_description)/urdf/cob4_sensorring/sensorring_asus.urdf.xacro" />
+  <xacro:include filename="$(find cob_description)/urdf/cob4_sensorring/sensorring.urdf.xacro" />
   <xacro:include filename="$(find cob_description)/urdf/sensors/kinect.urdf.xacro" />
 
   <!-- composition of the robot -->

--- a/cob_hardware_config/cob4-2/urdf/cob4-2.urdf.xacro
+++ b/cob_hardware_config/cob4-2/urdf/cob4-2.urdf.xacro
@@ -14,7 +14,7 @@
   <xacro:include filename="$(find cob_description)/urdf/cob4_base/base.urdf.xacro" />
 
   <!-- torso -->
-  <xacro:include filename="$(find cob_description)/urdf/cob4_torso/torso_2dof.urdf.xacro" />
+  <xacro:include filename="$(find cob_description)/urdf/cob4_torso/torso.urdf.xacro" />
 
   <!-- arm -->
   <xacro:include filename="$(find schunk_description)/urdf/lwa4p_extended/lwa4p_extended.urdf.xacro" />
@@ -42,7 +42,7 @@
     </plugin>
   </gazebo>
 
-  <xacro:torso name="torso" parent="base_link">
+  <xacro:torso name="torso" parent="base_link" dof1="false" dof2="true" dof3="true">
     <origin xyz="${torso_x} ${torso_y} ${torso_z}" rpy="${torso_roll} ${torso_pitch} ${torso_yaw}" />
   </xacro:torso>
   <!-- left camera -->

--- a/cob_hardware_config/cob4-2/urdf/cob4-2.urdf.xacro
+++ b/cob_hardware_config/cob4-2/urdf/cob4-2.urdf.xacro
@@ -28,6 +28,7 @@
 
   <!-- sensorring -->
   <xacro:include filename="$(find cob_description)/urdf/cob4_sensorring/sensorring_asus.urdf.xacro" />
+  <xacro:include filename="$(find cob_description)/urdf/sensors/kinect.urdf.xacro" />
 
   <!-- composition of the robot -->
   <xacro:base name="base" use_old_joint_names="false"/>
@@ -64,6 +65,9 @@
   <xacro:sensorring name="sensorring" parent="head_3_link">
     <origin xyz="${sensorring_x} ${sensorring_y} ${sensorring_z}" rpy="${sensorring_roll} ${sensorring_pitch} ${sensorring_yaw}" />
   </xacro:sensorring>
+  <xacro:cob_kinect_v0 name="sensorring_cam3d" ros_topic="sensorring_cam3d" parent="sensorring_link">
+    <origin xyz="${sensorring_cam3d_x} ${sensorring_cam3d_y} ${sensorring_cam3d_z}" rpy="${sensorring_cam3d_roll} ${sensorring_cam3d_pitch} ${sensorring_cam3d_yaw}" />
+  </xacro:cob_kinect_v0>
   <gazebo>
     <plugin name="ros_control" filename="libhwi_switch_gazebo_ros_control.so">
       <robotNamespace>sensorring</robotNamespace>

--- a/cob_hardware_config/cob4-2/urdf/cob4-2.urdf.xacro
+++ b/cob_hardware_config/cob4-2/urdf/cob4-2.urdf.xacro
@@ -24,11 +24,14 @@
 
   <!-- head -->
   <xacro:include filename="$(find cob_description)/urdf/cob4_head/head.urdf.xacro" />
-  <xacro:include filename="$(find cob_description)/urdf/sensors/usb_cam.urdf.xacro" />
 
   <!-- sensorring -->
   <xacro:include filename="$(find cob_description)/urdf/cob4_sensorring/sensorring.urdf.xacro" />
+
+  <!-- sensors -->
+  <xacro:include filename="$(find cob_description)/urdf/sensors/realsense.urdf.xacro" />
   <xacro:include filename="$(find cob_description)/urdf/sensors/kinect.urdf.xacro" />
+  <xacro:include filename="$(find cob_description)/urdf/sensors/usb_cam.urdf.xacro" />
 
   <!-- composition of the robot -->
   <xacro:base name="base" use_old_joint_names="false"/>
@@ -42,6 +45,18 @@
   <xacro:torso name="torso" parent="base_link">
     <origin xyz="${torso_x} ${torso_y} ${torso_z}" rpy="${torso_roll} ${torso_pitch} ${torso_yaw}" />
   </xacro:torso>
+  <!-- left camera -->
+  <xacro:cob_kinect_v0 name="torso_cam3d_left" ros_topic="torso_cam3d_left" parent="torso_3_link">
+    <origin xyz="${torso_cam3d_left_x} ${torso_cam3d_left_y} ${torso_cam3d_left_z}" rpy="${torso_cam3d_left_roll} ${torso_cam3d_left_pitch} ${torso_cam3d_left_yaw}" />
+  </xacro:cob_kinect_v0>
+  <!-- right camera -->
+  <xacro:cob_kinect_v0 name="torso_cam3d_right" ros_topic="torso_cam3d_right" parent="torso_3_link">
+    <origin xyz="${torso_cam3d_right_x} ${torso_cam3d_right_y} ${torso_cam3d_right_z}" rpy="${torso_cam3d_right_roll} ${torso_cam3d_right_pitch} ${torso_cam3d_right_yaw}" />
+  </xacro:cob_kinect_v0>
+  <!-- down camera -->
+  <xacro:realsense name="torso_cam3d_down" ros_topic="torso_cam3d_down" parent="torso_3_link">
+    <origin xyz="${torso_cam3d_down_x} ${torso_cam3d_down_y} ${torso_cam3d_down_z}" rpy="${torso_cam3d_down_roll} ${torso_cam3d_down_pitch} ${torso_cam3d_down_yaw}" />
+  </xacro:realsense>
   <gazebo>
     <plugin name="ros_control" filename="libhwi_switch_gazebo_ros_control.so">
       <robotNamespace>torso</robotNamespace>

--- a/cob_hardware_config/cob4-2/urdf/cob4-2.urdf.xacro
+++ b/cob_hardware_config/cob4-2/urdf/cob4-2.urdf.xacro
@@ -48,7 +48,7 @@
     </plugin>
   </gazebo>
 
-  <xacro:head name="head" parent="torso_3_link">
+  <xacro:head name="head" parent="torso_3_link" dof1="true" dof2="true" dof3="true">
     <origin xyz="${head_x} ${head_y} ${head_z}" rpy="${head_roll} ${head_pitch} ${head_yaw}" />
   </xacro:head>
   <xacro:usb_cam name="head_cam" parent="head_3_link" ros_topic="head_cam">

--- a/cob_hardware_config/cob4-2/urdf/cob4-2.urdf.xacro
+++ b/cob_hardware_config/cob4-2/urdf/cob4-2.urdf.xacro
@@ -27,7 +27,7 @@
   <xacro:include filename="$(find cob_description)/urdf/sensors/usb_cam.urdf.xacro" />
 
   <!-- sensorring -->
-  <xacro:include filename="$(find cob_description)/urdf/cob4_sensorring/sensorring_asus.urdf.xacro" />
+  <xacro:include filename="$(find cob_description)/urdf/cob4_sensorring/sensorring.urdf.xacro" />
   <xacro:include filename="$(find cob_description)/urdf/sensors/kinect.urdf.xacro" />
 
   <!-- composition of the robot -->

--- a/cob_hardware_config/cob4-2/urdf/cob4-2.urdf.xacro
+++ b/cob_hardware_config/cob4-2/urdf/cob4-2.urdf.xacro
@@ -24,6 +24,7 @@
 
   <!-- head -->
   <xacro:include filename="$(find cob_description)/urdf/cob4_head/head.urdf.xacro" />
+  <xacro:include filename="$(find cob_description)/urdf/sensors/usb_cam.urdf.xacro" />
 
   <!-- sensorring -->
   <xacro:include filename="$(find cob_description)/urdf/cob4_sensorring/sensorring_asus.urdf.xacro" />
@@ -50,6 +51,9 @@
   <xacro:head name="head" parent="torso_3_link">
     <origin xyz="${head_x} ${head_y} ${head_z}" rpy="${head_roll} ${head_pitch} ${head_yaw}" />
   </xacro:head>
+  <xacro:usb_cam name="head_cam" parent="head_3_link" ros_topic="head_cam">
+    <origin xyz="${head_cam_x} ${head_cam_y} ${head_cam_z}" rpy="${head_cam_roll} ${head_cam_pitch} ${head_cam_yaw}" />
+  </xacro:usb_cam>
   <gazebo>
     <plugin name="ros_control" filename="libhwi_switch_gazebo_ros_control.so">
       <robotNamespace>head</robotNamespace>

--- a/cob_hardware_config/cob4-5/urdf/cob4-5.urdf.xacro
+++ b/cob_hardware_config/cob4-5/urdf/cob4-5.urdf.xacro
@@ -23,7 +23,7 @@
   <xacro:include filename="$(find cob_description)/urdf/cob4_gripper/gripper.urdf.xacro" />
 
   <!-- head -->
-  <xacro:include filename="$(find cob_description)/urdf/cob4_head/head_static.urdf.xacro" />
+  <xacro:include filename="$(find cob_description)/urdf/cob4_head/head.urdf.xacro" />
   <xacro:include filename="$(find cob_description)/urdf/sensors/usb_cam.urdf.xacro" />
 
   <!-- sensorring -->
@@ -42,7 +42,7 @@
     <origin xyz="${torso_x} ${torso_y} ${torso_z}" rpy="${torso_roll} ${torso_pitch} ${torso_yaw}" />
   </xacro:torso>
 
-  <xacro:head name="head" parent="torso_3_link">
+  <xacro:head name="head" parent="torso_3_link" dof1="false" dof2="false" dof3="false">
     <origin xyz="${head_x} ${head_y} ${head_z}" rpy="${head_roll} ${head_pitch} ${head_yaw}" />
   </xacro:head>
   <xacro:usb_cam name="head_cam" parent="head_3_link" ros_topic="head_cam">

--- a/cob_hardware_config/cob4-5/urdf/cob4-5.urdf.xacro
+++ b/cob_hardware_config/cob4-5/urdf/cob4-5.urdf.xacro
@@ -14,7 +14,7 @@
   <xacro:include filename="$(find cob_description)/urdf/cob4_base/base.urdf.xacro" />
 
   <!-- torso -->
-  <xacro:include filename="$(find cob_description)/urdf/cob4_torso/torso_static.urdf.xacro" />
+  <xacro:include filename="$(find cob_description)/urdf/cob4_torso/torso.urdf.xacro" />
 
   <!-- arm -->
   <xacro:include filename="$(find schunk_description)/urdf/lwa4p_extended/lwa4p_extended.urdf.xacro" />
@@ -43,7 +43,7 @@
     </plugin>
   </gazebo>
 
-  <xacro:torso name="torso" parent="base_link">
+  <xacro:torso name="torso" parent="base_link" dof1="false" dof2="false" dof3="false">
     <origin xyz="${torso_x} ${torso_y} ${torso_z}" rpy="${torso_roll} ${torso_pitch} ${torso_yaw}" />
   </xacro:torso>
   <!-- left camera -->

--- a/cob_hardware_config/cob4-5/urdf/cob4-5.urdf.xacro
+++ b/cob_hardware_config/cob4-5/urdf/cob4-5.urdf.xacro
@@ -27,7 +27,7 @@
   <xacro:include filename="$(find cob_description)/urdf/sensors/usb_cam.urdf.xacro" />
 
   <!-- sensorring -->
-  <xacro:include filename="$(find cob_description)/urdf/cob4_sensorring/sensorring_3dcs_asus.urdf.xacro" />
+  <xacro:include filename="$(find cob_description)/urdf/cob4_sensorring/sensorring.urdf.xacro" />
   <xacro:include filename="$(find cob_description)/urdf/sensors/sick_3dcs.urdf.xacro" />
   <xacro:include filename="$(find cob_description)/urdf/sensors/kinect.urdf.xacro" />
 

--- a/cob_hardware_config/cob4-5/urdf/cob4-5.urdf.xacro
+++ b/cob_hardware_config/cob4-5/urdf/cob4-5.urdf.xacro
@@ -24,6 +24,7 @@
 
   <!-- head -->
   <xacro:include filename="$(find cob_description)/urdf/cob4_head/head_static.urdf.xacro" />
+  <xacro:include filename="$(find cob_description)/urdf/sensors/usb_cam.urdf.xacro" />
 
   <!-- sensorring -->
   <xacro:include filename="$(find cob_description)/urdf/cob4_sensorring/sensorring_3dcs_asus.urdf.xacro" />
@@ -44,6 +45,9 @@
   <xacro:head name="head" parent="torso_3_link">
     <origin xyz="${head_x} ${head_y} ${head_z}" rpy="${head_roll} ${head_pitch} ${head_yaw}" />
   </xacro:head>
+  <xacro:usb_cam name="head_cam" parent="head_3_link" ros_topic="head_cam">
+    <origin xyz="${head_cam_x} ${head_cam_y} ${head_cam_z}" rpy="${head_cam_roll} ${head_cam_pitch} ${head_cam_yaw}" />
+  </xacro:usb_cam>
 
   <xacro:sensorring name="sensorring" parent="head_3_link">
     <origin xyz="${sensorring_x} ${sensorring_y} ${sensorring_z}" rpy="${sensorring_roll} ${sensorring_pitch} ${sensorring_yaw}" />

--- a/cob_hardware_config/cob4-5/urdf/cob4-5.urdf.xacro
+++ b/cob_hardware_config/cob4-5/urdf/cob4-5.urdf.xacro
@@ -24,12 +24,15 @@
 
   <!-- head -->
   <xacro:include filename="$(find cob_description)/urdf/cob4_head/head.urdf.xacro" />
-  <xacro:include filename="$(find cob_description)/urdf/sensors/usb_cam.urdf.xacro" />
 
   <!-- sensorring -->
   <xacro:include filename="$(find cob_description)/urdf/cob4_sensorring/sensorring.urdf.xacro" />
-  <xacro:include filename="$(find cob_description)/urdf/sensors/sick_3dcs.urdf.xacro" />
+
+  <!-- sensors -->
+  <xacro:include filename="$(find cob_description)/urdf/sensors/realsense.urdf.xacro" />
   <xacro:include filename="$(find cob_description)/urdf/sensors/kinect.urdf.xacro" />
+  <xacro:include filename="$(find cob_description)/urdf/sensors/usb_cam.urdf.xacro" />
+  <xacro:include filename="$(find cob_description)/urdf/sensors/sick_3dcs.urdf.xacro" />
 
   <!-- composition of the robot -->
   <xacro:base name="base" use_old_joint_names="false"/>
@@ -43,6 +46,18 @@
   <xacro:torso name="torso" parent="base_link">
     <origin xyz="${torso_x} ${torso_y} ${torso_z}" rpy="${torso_roll} ${torso_pitch} ${torso_yaw}" />
   </xacro:torso>
+  <!-- left camera -->
+  <xacro:cob_kinect_v0 name="torso_cam3d_left" ros_topic="torso_cam3d_left" parent="torso_3_link">
+    <origin xyz="${torso_cam3d_left_x} ${torso_cam3d_left_y} ${torso_cam3d_left_z}" rpy="${torso_cam3d_left_roll} ${torso_cam3d_left_pitch} ${torso_cam3d_left_yaw}" />
+  </xacro:cob_kinect_v0>
+  <!-- right camera -->
+  <xacro:cob_kinect_v0 name="torso_cam3d_right" ros_topic="torso_cam3d_right" parent="torso_3_link">
+    <origin xyz="${torso_cam3d_right_x} ${torso_cam3d_right_y} ${torso_cam3d_right_z}" rpy="${torso_cam3d_right_roll} ${torso_cam3d_right_pitch} ${torso_cam3d_right_yaw}" />
+  </xacro:cob_kinect_v0>
+  <!-- down camera -->
+  <xacro:realsense name="torso_cam3d_down" ros_topic="torso_cam3d_down" parent="torso_3_link">
+    <origin xyz="${torso_cam3d_down_x} ${torso_cam3d_down_y} ${torso_cam3d_down_z}" rpy="${torso_cam3d_down_roll} ${torso_cam3d_down_pitch} ${torso_cam3d_down_yaw}" />
+  </xacro:realsense>
 
   <xacro:head name="head" parent="torso_3_link" dof1="false" dof2="false" dof3="false">
     <origin xyz="${head_x} ${head_y} ${head_z}" rpy="${head_roll} ${head_pitch} ${head_yaw}" />

--- a/cob_hardware_config/cob4-5/urdf/cob4-5.urdf.xacro
+++ b/cob_hardware_config/cob4-5/urdf/cob4-5.urdf.xacro
@@ -28,6 +28,8 @@
 
   <!-- sensorring -->
   <xacro:include filename="$(find cob_description)/urdf/cob4_sensorring/sensorring_3dcs_asus.urdf.xacro" />
+  <xacro:include filename="$(find cob_description)/urdf/sensors/sick_3dcs.urdf.xacro" />
+  <xacro:include filename="$(find cob_description)/urdf/sensors/kinect.urdf.xacro" />
 
   <!-- composition of the robot -->
   <xacro:base name="base" use_old_joint_names="false"/>
@@ -52,6 +54,13 @@
   <xacro:sensorring name="sensorring" parent="head_3_link">
     <origin xyz="${sensorring_x} ${sensorring_y} ${sensorring_z}" rpy="${sensorring_roll} ${sensorring_pitch} ${sensorring_yaw}" />
   </xacro:sensorring>
+  <!-- cameras -->
+  <xacro:sick_3dcs name="sensorring_cam3d_front" ros_topic="sensorring_cam3d_front" parent="sensorring_link">
+    <origin xyz="${sensorring_cam3d_front_x} ${sensorring_cam3d_front_y} ${sensorring_cam3d_front_z}" rpy="${sensorring_cam3d_front_roll} ${sensorring_cam3d_front_pitch} ${sensorring_cam3d_front_yaw}" />
+  </xacro:sick_3dcs>
+  <xacro:cob_kinect_v0 name="sensorring_cam3d_back" ros_topic="sensorring_cam3d_back" parent="sensorring_link">
+    <origin xyz="${sensorring_cam3d_back_x} ${sensorring_cam3d_back_y} ${sensorring_cam3d_back_z}" rpy="${sensorring_cam3d_back_roll} ${sensorring_cam3d_back_pitch} ${sensorring_cam3d_back_yaw}" />
+  </xacro:cob_kinect_v0>
   <gazebo>
     <plugin name="ros_control" filename="libhwi_switch_gazebo_ros_control.so">
       <robotNamespace>sensorring</robotNamespace>

--- a/cob_hardware_config/cob4-7/urdf/cob4-7.urdf.xacro
+++ b/cob_hardware_config/cob4-7/urdf/cob4-7.urdf.xacro
@@ -21,6 +21,7 @@
 
   <!-- head -->
   <xacro:include filename="$(find cob_description)/urdf/cob4_head/head.urdf.xacro" />
+  <xacro:include filename="$(find cob_description)/urdf/sensors/usb_cam.urdf.xacro" />
 
   <!-- sensorring -->
   <xacro:include filename="$(find cob_description)/urdf/cob4_sensorring/sensorring_asus.urdf.xacro" />
@@ -67,6 +68,9 @@
   <xacro:head name="head" parent="torso_3_link">
     <origin xyz="${head_x} ${head_y} ${head_z}" rpy="${head_roll} ${head_pitch} ${head_yaw}" />
   </xacro:head>
+  <xacro:usb_cam name="head_cam" parent="head_3_link" ros_topic="head_cam">
+    <origin xyz="${head_cam_x} ${head_cam_y} ${head_cam_z}" rpy="${head_cam_roll} ${head_cam_pitch} ${head_cam_yaw}" />
+  </xacro:usb_cam>
   <gazebo>
     <plugin name="ros_control" filename="libhwi_switch_gazebo_ros_control.so">
       <robotNamespace>head</robotNamespace>

--- a/cob_hardware_config/cob4-7/urdf/cob4-7.urdf.xacro
+++ b/cob_hardware_config/cob4-7/urdf/cob4-7.urdf.xacro
@@ -21,11 +21,14 @@
 
   <!-- head -->
   <xacro:include filename="$(find cob_description)/urdf/cob4_head/head.urdf.xacro" />
-  <xacro:include filename="$(find cob_description)/urdf/sensors/usb_cam.urdf.xacro" />
 
   <!-- sensorring -->
   <xacro:include filename="$(find cob_description)/urdf/cob4_sensorring/sensorring.urdf.xacro" />
+
+  <!-- sensors -->
+  <xacro:include filename="$(find cob_description)/urdf/sensors/realsense.urdf.xacro" />
   <xacro:include filename="$(find cob_description)/urdf/sensors/kinect.urdf.xacro" />
+  <xacro:include filename="$(find cob_description)/urdf/sensors/usb_cam.urdf.xacro" />
 
   <!-- composition of the robot -->
   <xacro:base name="base" use_old_joint_names="false"/>
@@ -39,6 +42,18 @@
   <xacro:torso name="torso" parent="base_link">
     <origin xyz="${torso_x} ${torso_y} ${torso_z}" rpy="${torso_roll} ${torso_pitch} ${torso_yaw}" />
   </xacro:torso>
+  <!-- left camera -->
+  <xacro:cob_kinect_v0 name="torso_cam3d_left" ros_topic="torso_cam3d_left" parent="torso_3_link">
+    <origin xyz="${torso_cam3d_left_x} ${torso_cam3d_left_y} ${torso_cam3d_left_z}" rpy="${torso_cam3d_left_roll} ${torso_cam3d_left_pitch} ${torso_cam3d_left_yaw}" />
+  </xacro:cob_kinect_v0>
+  <!-- right camera -->
+  <xacro:cob_kinect_v0 name="torso_cam3d_right" ros_topic="torso_cam3d_right" parent="torso_3_link">
+    <origin xyz="${torso_cam3d_right_x} ${torso_cam3d_right_y} ${torso_cam3d_right_z}" rpy="${torso_cam3d_right_roll} ${torso_cam3d_right_pitch} ${torso_cam3d_right_yaw}" />
+  </xacro:cob_kinect_v0>
+  <!-- down camera -->
+  <xacro:realsense name="torso_cam3d_down" ros_topic="torso_cam3d_down" parent="torso_3_link">
+    <origin xyz="${torso_cam3d_down_x} ${torso_cam3d_down_y} ${torso_cam3d_down_z}" rpy="${torso_cam3d_down_roll} ${torso_cam3d_down_pitch} ${torso_cam3d_down_yaw}" />
+  </xacro:realsense>
   <gazebo>
     <plugin name="ros_control" filename="libhwi_switch_gazebo_ros_control.so">
       <robotNamespace>torso</robotNamespace>

--- a/cob_hardware_config/cob4-7/urdf/cob4-7.urdf.xacro
+++ b/cob_hardware_config/cob4-7/urdf/cob4-7.urdf.xacro
@@ -14,7 +14,7 @@
   <xacro:include filename="$(find cob_description)/urdf/cob4_base/base.urdf.xacro" />
 
   <!-- torso -->
-  <xacro:include filename="$(find cob_description)/urdf/cob4_torso/torso_2dof.urdf.xacro" />
+  <xacro:include filename="$(find cob_description)/urdf/cob4_torso/torso.urdf.xacro" />
 
   <!-- arm -->
   <xacro:include filename="$(find schunk_description)/urdf/lwa4p_extended/lwa4p_extended.urdf.xacro" />
@@ -39,7 +39,7 @@
     </plugin>
   </gazebo>
 
-  <xacro:torso name="torso" parent="base_link">
+  <xacro:torso name="torso" parent="base_link" dof1="false" dof2="true" dof3="true">
     <origin xyz="${torso_x} ${torso_y} ${torso_z}" rpy="${torso_roll} ${torso_pitch} ${torso_yaw}" />
   </xacro:torso>
   <!-- left camera -->

--- a/cob_hardware_config/cob4-7/urdf/cob4-7.urdf.xacro
+++ b/cob_hardware_config/cob4-7/urdf/cob4-7.urdf.xacro
@@ -65,7 +65,7 @@
     </plugin>
   </gazebo>
 
-  <xacro:head name="head" parent="torso_3_link">
+  <xacro:head name="head" parent="torso_3_link" dof1="true" dof2="true" dof3="true">
     <origin xyz="${head_x} ${head_y} ${head_z}" rpy="${head_roll} ${head_pitch} ${head_yaw}" />
   </xacro:head>
   <xacro:usb_cam name="head_cam" parent="head_3_link" ros_topic="head_cam">

--- a/cob_hardware_config/cob4-7/urdf/cob4-7.urdf.xacro
+++ b/cob_hardware_config/cob4-7/urdf/cob4-7.urdf.xacro
@@ -25,6 +25,7 @@
 
   <!-- sensorring -->
   <xacro:include filename="$(find cob_description)/urdf/cob4_sensorring/sensorring_asus.urdf.xacro" />
+  <xacro:include filename="$(find cob_description)/urdf/sensors/kinect.urdf.xacro" />
 
   <!-- composition of the robot -->
   <xacro:base name="base" use_old_joint_names="false"/>
@@ -81,6 +82,9 @@
   <xacro:sensorring name="sensorring" parent="head_3_link">
     <origin xyz="${sensorring_x} ${sensorring_y} ${sensorring_z}" rpy="${sensorring_roll} ${sensorring_pitch} ${sensorring_yaw}" />
   </xacro:sensorring>
+  <xacro:cob_kinect_v0 name="sensorring_cam3d" ros_topic="sensorring_cam3d" parent="sensorring_link">
+    <origin xyz="${sensorring_cam3d_x} ${sensorring_cam3d_y} ${sensorring_cam3d_z}" rpy="${sensorring_cam3d_roll} ${sensorring_cam3d_pitch} ${sensorring_cam3d_yaw}" />
+  </xacro:cob_kinect_v0>
   <gazebo>
     <plugin name="ros_control" filename="libhwi_switch_gazebo_ros_control.so">
       <robotNamespace>sensorring</robotNamespace>

--- a/cob_hardware_config/cob4-7/urdf/cob4-7.urdf.xacro
+++ b/cob_hardware_config/cob4-7/urdf/cob4-7.urdf.xacro
@@ -24,7 +24,7 @@
   <xacro:include filename="$(find cob_description)/urdf/sensors/usb_cam.urdf.xacro" />
 
   <!-- sensorring -->
-  <xacro:include filename="$(find cob_description)/urdf/cob4_sensorring/sensorring_asus.urdf.xacro" />
+  <xacro:include filename="$(find cob_description)/urdf/cob4_sensorring/sensorring.urdf.xacro" />
   <xacro:include filename="$(find cob_description)/urdf/sensors/kinect.urdf.xacro" />
 
   <!-- composition of the robot -->


### PR DESCRIPTION
makes use of simplified/unified component macros provided in https://github.com/ipa320/cob_common/pull/198

the macro includes for the component sensors have been copied from the respective component macro, __i.e. there should absolutely be no difference in the robot_description at all__