### PR TITLE
coupled sensorring and head in one instance with helper

### DIFF
--- a/cob_bringup/drivers/canopen_shared_bus.launch
+++ b/cob_bringup/drivers/canopen_shared_bus.launch
@@ -1,0 +1,43 @@
+<?xml version="1.0"?>
+<launch>
+
+    <arg name="robot" default="$(optenv ROBOT !!NO_ROBOT_SET!!)"/>
+    <arg name="pkg_hardware_config" default="$(find cob_hardware_config)"/>
+    <arg name="can_device"/>
+    <arg name="master_component"/>
+    <arg name="slave_component"/>
+
+    <group ns="$(arg slave_component)">
+        <!-- relays for script server and custom scripts -->
+        <node name="$(arg slave_component)_init_relay" pkg="service_tools" type="service_relay" args="driver/init /$(arg master_component)/driver/init" respawn="false" output="screen"/>
+        <node name="$(arg slave_component)_recover_relay" pkg="service_tools" type="service_relay" args="driver/recover /$(arg master_component)/driver/recover" respawn="false" output="screen"/>
+        <node name="$(arg slave_component)_joint_states_relay" pkg="topic_tools" type="relay" args="/$(arg master_component)/joint_states joint_states" respawn="false" output="screen"/>
+
+        <!-- load controller config -->
+        <rosparam command="load" file="$(arg pkg_hardware_config)/$(arg robot)/config/$(arg slave_component)_controller.yaml" />
+
+        <!-- force absolute controller names -->
+        <param name="joint_trajectory_controller_name" value="/$(arg slave_component)/joint_trajectory_controller"/>
+        <param name="joint_group_position_controller_name" value="/$(arg slave_component)/joint_group_position_controller"/>
+        <param name="joint_group_velocity_controller_name" value="/$(arg slave_component)/joint_group_velocity_controller"/>
+
+        <remap from="controller_manager/load_controller" to="/$(arg master_component)/controller_manager/load_controller"/>
+        <remap from="controller_manager/switch_controller" to="/$(arg master_component)/controller_manager/switch_controller"/>
+
+        <node pkg="cob_control_mode_adapter" type="cob_control_mode_adapter_node" name="control_mode_adapter" cwd="node" respawn="false" output="screen"/>
+    </group>
+
+    <!-- remaps for rqt_joint_trajectory_controller -->
+    <remap from="/$(arg slave_component)/joint_trajectory_controller/command" to="/$(arg master_component)/$(arg slave_component)/joint_trajectory_controller/command"/>
+    <remap from="/$(arg slave_component)/joint_trajectory_controller/state" to="/$(arg master_component)/$(arg slave_component)/joint_trajectory_controller/state"/>
+
+    <include file="$(find cob_bringup)/drivers/canopen_402.launch">
+        <arg name="robot" value="$(arg robot)"/>
+        <arg name="component_name" value="$(arg master_component)"/>
+        <arg name="can_device" value="$(arg can_device)"/>
+    </include>
+    <include file="$(find cob_bringup)/controllers/generic_controller.launch">
+        <arg name="robot" value="$(arg robot)"/>
+        <arg name="component_name" value="$(arg master_component)"/>
+    </include>
+</launch>

--- a/cob_bringup/package.xml
+++ b/cob_bringup/package.xml
@@ -92,6 +92,7 @@
   <exec_depend>rviz</exec_depend>
   <exec_depend>schunk_powercube_chain</exec_depend>
   <exec_depend>schunk_sdh</exec_depend>
+  <exec_depend>service_tools</exec_depend>
   <exec_depend>sick_visionary_t_driver</exec_depend>
   <exec_depend>spacenav_node</exec_depend>
   <exec_depend>topic_tools</exec_depend>

--- a/cob_bringup/robots/cob4-10.xml
+++ b/cob_bringup/robots/cob4-10.xml
@@ -124,24 +124,11 @@
             <arg name="component_name" value="torso"/>
         </include>
 
-        <include file="$(find cob_bringup)/drivers/canopen_402.launch">
+        <include file="$(find cob_bringup)/drivers/canopen_shared_bus.launch">
             <arg name="robot" value="$(arg robot)"/>
-            <arg name="component_name" value="sensorring"/>
+            <arg name="master_component" value="head"/>
+            <arg name="slave_component" value="sensorring"/>
             <arg name="can_device" value="can1"/>
-        </include>
-        <include file="$(find cob_bringup)/controllers/generic_controller.launch">
-            <arg name="robot" value="$(arg robot)"/>
-            <arg name="component_name" value="sensorring"/>
-        </include>
-
-        <include file="$(find cob_bringup)/drivers/canopen_402.launch">
-            <arg name="robot" value="$(arg robot)"/>
-            <arg name="component_name" value="head"/>
-            <arg name="can_device" value="can1"/>
-        </include>
-        <include file="$(find cob_bringup)/controllers/generic_controller.launch">
-            <arg name="robot" value="$(arg robot)"/>
-            <arg name="component_name" value="head"/>
         </include>
 
         <include file="$(find cob_bringup)/drivers/openni2.launch">

--- a/cob_hardware_config/cob4-10/config/head_driver.yaml
+++ b/cob_hardware_config/cob4-10/config/head_driver.yaml
@@ -1,1 +1,54 @@
-../../cob4-7/config/head_driver.yaml
+sync:
+  interval_ms: 10
+  overflow: 0
+heartbeat:
+  rate: 20
+  msg: "77f#05"
+
+defaults:
+  eds_pkg: cob_hardware_config
+  eds_file: "common/Elmo.dcf"
+  vel_from_device: "v != v ? v=0 : v=smooth(deg2rad(obj606c/1000.0),v,0.3)" # for smoother current velocity in joint_states
+  motor_layer:
+    switching_state: 4 # switched on - stop controller before switching modes
+  dcf_overlay:
+    "1016sub1" : "0x7F0064" # heartbeat timeout of 100 ms for master at 127
+
+nodes:
+#  - name: head_1_joint
+#    id: 70
+#    #publish: ["60C1sub1"]   #trajectory
+#    #publish: ["60FF"]       #velocity
+#    dcf_overlay: # "ObjectID": "ParameterValue" (both as strings)
+#      "6083": "300000" # profile acceleration, mgrad/sec^2
+#      "6084": "300000" # profile deceleration, mgrad/sec^2
+#      "60C5": "300000" # max acceleration, mgrad/sec^2
+#      "60C6": "1000000" # max deceleration, mgrad/sec^2
+  - name: head_2_joint
+    id: 71
+    #publish: ["60C1sub1"]   #trajectory
+    #publish: ["60FF"]       #velocity
+    dcf_overlay: # "ObjectID": "ParameterValue" (both as strings)
+      "6083": "300000" # profile acceleration, mgrad/sec^2
+      "6084": "300000" # profile deceleration, mgrad/sec^2
+      "60C5": "300000" # max acceleration, mgrad/sec^2
+      "60C6": "1000000" # max deceleration, mgrad/sec^2
+  - name: head_3_joint
+    id: 72
+    #publish: ["60C1sub1"]   #trajectory
+    #publish: ["60FF"]       #velocity
+    dcf_overlay: # "ObjectID": "ParameterValue" (both as strings)
+      "6083": "300000" # profile acceleration, mgrad/sec^2
+      "6084": "300000" # profile deceleration, mgrad/sec^2
+      "60C5": "300000" # max acceleration, mgrad/sec^2
+      "60C6": "1000000" # max deceleration, mgrad/sec^2
+  - name: sensorring_joint
+    id: 73
+    #publish: ["60C1sub1"]   #trajectory
+    #publish: ["60FF"]       #velocity
+    dcf_overlay: # "ObjectID": "ParameterValue" (both as strings)
+      "6083": "300000" # profile acceleration, mgrad/sec^2
+      "6084": "300000" # profile deceleration, mgrad/sec^2
+      "60C5": "300000" # max acceleration, mgrad/sec^2
+      "60C6": "1000000" # max deceleration, mgrad/sec^2
+

--- a/cob_hardware_config/cob4-10/config/joint_state_publisher.yaml
+++ b/cob_hardware_config/cob4-10/config/joint_state_publisher.yaml
@@ -1,2 +1,2 @@
 rate: 100 #Hz
-source_list: [/base/joint_states, /torso/joint_states, /sensorring/joint_states, /head/joint_states]
+source_list: [/base/joint_states, /torso/joint_states, /head/joint_states]

--- a/cob_hardware_config/cob4-10/config/sensorring_driver.yaml
+++ b/cob_hardware_config/cob4-10/config/sensorring_driver.yaml
@@ -1,1 +1,0 @@
-../../cob4-7/config/sensorring_driver.yaml


### PR DESCRIPTION
supersedes #561

not yet tested on real hardware, but controllers can be loaded as expected.

Pros:
* does not mess with the controller config files (works nice with gazebo)
* rqt_joint_controller_manager works

Cons:
* slave controllers have absolute names
* slave controllers cannot be loaded with rqt_controller_manager