### PR TITLE
Restructure moveit config

### DIFF
--- a/cob_bringup/robots/cob4-1.xml
+++ b/cob_bringup/robots/cob4-1.xml
@@ -15,6 +15,12 @@
     <include file="$(find cob_hardware_config)/common/upload_robot.launch">
         <arg name="robot" value="$(arg robot)"/>
     </include>
+    <!-- upload semantic description -->
+    <include file="$(find cob_moveit_config)/launch/upload_config.launch">
+        <arg name="robot" value="$(arg robot)"/>
+        <arg name="load_semantic_description" value="true"/>
+        <arg name="load_planning_context" value="false"/>
+    </include>
 
     <!-- upload default configuration parameters -->
     <include file="$(find cob_default_robot_config)/$(arg robot)/upload_param_$(arg robot).launch"/>
@@ -46,8 +52,7 @@
         <include file="$(find cob_bringup)/drivers/sick_flexisoft.launch">
             <arg name="robot" value="$(arg robot)"/>
         </include>
-        <!--include file="$(find cob_bringup)/tools/collision_monitor.launch">
-        </include-->
+        <!-- <include file="$(find cob_bringup)/tools/collision_monitor.launch"> -->
         <node pkg="rostopic" type="rostopic" args="pub /safety_controller/state_is_valid std_msgs/Bool 'data: true' -r10" name="fake_collission_monitor" output="screen"/>
 
         <include file="$(find cob_bringup)/drivers/canopen_402.launch">

--- a/cob_bringup/robots/cob4-10.xml
+++ b/cob_bringup/robots/cob4-10.xml
@@ -15,6 +15,12 @@
     <include file="$(find cob_hardware_config)/common/upload_robot.launch">
         <arg name="robot" value="$(arg robot)"/>
     </include>
+    <!-- upload semantic description -->
+    <include file="$(find cob_moveit_config)/launch/upload_config.launch">
+        <arg name="robot" value="$(arg robot)"/>
+        <arg name="load_semantic_description" value="true"/>
+        <arg name="load_planning_context" value="false"/>
+    </include>
 
     <!-- upload default configuration parameters -->
     <include file="$(find cob_default_robot_config)/$(arg robot)/upload_param_$(arg robot).launch"/>
@@ -46,8 +52,7 @@
         <include file="$(find cob_bringup)/drivers/sick_flexisoft.launch">
             <arg name="robot" value="$(arg robot)"/>
         </include>
-        <!--include file="$(find cob_bringup)/tools/collision_monitor.launch">
-        </include-->
+        <!-- <include file="$(find cob_bringup)/tools/collision_monitor.launch"> -->
         <node pkg="rostopic" type="rostopic" args="pub /safety_controller/state_is_valid std_msgs/Bool 'data: true' -r10" name="fake_collission_monitor" output="screen"/>
 
         <include file="$(find cob_bringup)/drivers/canopen_402.launch">

--- a/cob_bringup/robots/cob4-2.xml
+++ b/cob_bringup/robots/cob4-2.xml
@@ -15,6 +15,12 @@
     <include file="$(find cob_hardware_config)/common/upload_robot.launch">
         <arg name="robot" value="$(arg robot)"/>
     </include>
+    <!-- upload semantic description -->
+    <include file="$(find cob_moveit_config)/launch/upload_config.launch">
+        <arg name="robot" value="$(arg robot)"/>
+        <arg name="load_semantic_description" value="true"/>
+        <arg name="load_planning_context" value="false"/>
+    </include>
 
     <!-- upload default configuration parameters -->
     <include file="$(find cob_default_robot_config)/$(arg robot)/upload_param_$(arg robot).launch"/>
@@ -46,8 +52,7 @@
         <include file="$(find cob_bringup)/drivers/sick_flexisoft.launch">
             <arg name="robot" value="$(arg robot)"/>
         </include>
-        <!--include file="$(find cob_bringup)/tools/collision_monitor.launch">
-        </include-->
+        <!-- <include file="$(find cob_bringup)/tools/collision_monitor.launch"> -->
         <node pkg="rostopic" type="rostopic" args="pub /safety_controller/state_is_valid std_msgs/Bool 'data: true' -r10" name="fake_collission_monitor" output="screen"/>
 
         <include file="$(find cob_bringup)/drivers/canopen_402.launch">

--- a/cob_bringup/robots/cob4-7.xml
+++ b/cob_bringup/robots/cob4-7.xml
@@ -15,6 +15,12 @@
     <include file="$(find cob_hardware_config)/common/upload_robot.launch">
         <arg name="robot" value="$(arg robot)"/>
     </include>
+    <!-- upload semantic description -->
+    <include file="$(find cob_moveit_config)/launch/upload_config.launch">
+        <arg name="robot" value="$(arg robot)"/>
+        <arg name="load_semantic_description" value="true"/>
+        <arg name="load_planning_context" value="false"/>
+    </include>
 
     <!-- upload default configuration parameters -->
     <include file="$(find cob_default_robot_config)/$(arg robot)/upload_param_$(arg robot).launch"/>
@@ -46,8 +52,7 @@
         <include file="$(find cob_bringup)/drivers/sick_flexisoft.launch">
             <arg name="robot" value="$(arg robot)"/>
         </include>
-        <!--include file="$(find cob_bringup)/tools/collision_monitor.launch">
-        </include-->
+        <!-- <include file="$(find cob_bringup)/tools/collision_monitor.launch"> -->
         <node pkg="rostopic" type="rostopic" args="pub /safety_controller/state_is_valid std_msgs/Bool 'data: true' -r10" name="fake_collission_monitor" output="screen"/>
 
         <include file="$(find cob_bringup)/drivers/canopen_402.launch">

--- a/cob_hardware_config/cob3-2/srdf/cob3-2.srdf
+++ b/cob_hardware_config/cob3-2/srdf/cob3-2.srdf
@@ -1,3 +1,0 @@
-<?xml version="1.0" ?>
-<robot name="cob3-2">
-</robot>

--- a/cob_hardware_config/cob3-6/srdf/cob3-6.srdf
+++ b/cob_hardware_config/cob3-6/srdf/cob3-6.srdf
@@ -1,3 +1,0 @@
-<?xml version="1.0" ?>
-<robot name="cob3-6">
-</robot>

--- a/cob_hardware_config/cob3-9/srdf/cob3-9.srdf
+++ b/cob_hardware_config/cob3-9/srdf/cob3-9.srdf
@@ -1,3 +1,0 @@
-<?xml version="1.0" ?>
-<robot name="cob3-9">
-</robot>

--- a/cob_hardware_config/cob4-1/srdf/cob4-1.srdf
+++ b/cob_hardware_config/cob4-1/srdf/cob4-1.srdf
@@ -1,9 +1,0 @@
-<?xml version="1.0" ?>
-<robot name="cob4-1">
-    <disable_collisions link1="base_link" link2="torso_1_link" reason="Never" />
-    <disable_collisions link1="base_link" link2="torso_2_link" reason="Never" />
-    <disable_collisions link1="base_link" link2="torso_3_link" reason="Never" />
-    <disable_collisions link1="torso_3_link" link2="head_1_link" reason="Never" />
-    <disable_collisions link1="torso_3_link" link2="head_2_link" reason="Never" />
-    <disable_collisions link1="torso_3_link" link2="head_3_link" reason="Never" />
-</robot>

--- a/cob_hardware_config/cob4-10/srdf/cob4-10.srdf
+++ b/cob_hardware_config/cob4-10/srdf/cob4-10.srdf
@@ -1,3 +1,0 @@
-<?xml version="1.0" ?>
-<robot name="cob4-7">
-</robot>

--- a/cob_hardware_config/cob4-2/srdf/cob4-2.srdf
+++ b/cob_hardware_config/cob4-2/srdf/cob4-2.srdf
@@ -1,9 +1,0 @@
-<?xml version="1.0" ?>
-<robot name="cob4-2">
-    <disable_collisions link1="base_link" link2="torso_1_link" reason="Never" />
-    <disable_collisions link1="base_link" link2="torso_2_link" reason="Never" />
-    <disable_collisions link1="base_link" link2="torso_3_link" reason="Never" />
-    <disable_collisions link1="torso_3_link" link2="head_1_link" reason="Never" />
-    <disable_collisions link1="torso_3_link" link2="head_2_link" reason="Never" />
-    <disable_collisions link1="torso_3_link" link2="head_3_link" reason="Never" />
-</robot>

--- a/cob_hardware_config/cob4-3/srdf/cob4-3.srdf
+++ b/cob_hardware_config/cob4-3/srdf/cob4-3.srdf
@@ -1,3 +1,0 @@
-<?xml version="1.0" ?>
-<robot name="cob4-3">
-</robot>

--- a/cob_hardware_config/cob4-4/srdf/cob4-4.srdf
+++ b/cob_hardware_config/cob4-4/srdf/cob4-4.srdf
@@ -1,3 +1,0 @@
-<?xml version="1.0" ?>
-<robot name="cob4-4">
-</robot>

--- a/cob_hardware_config/cob4-5/srdf/cob4-5.srdf
+++ b/cob_hardware_config/cob4-5/srdf/cob4-5.srdf
@@ -1,3 +1,0 @@
-<?xml version="1.0" ?>
-<robot name="cob4-5">
-</robot>

--- a/cob_hardware_config/cob4-6/srdf/cob4-6.srdf
+++ b/cob_hardware_config/cob4-6/srdf/cob4-6.srdf
@@ -1,3 +1,0 @@
-<?xml version="1.0" ?>
-<robot name="cob4-6">
-</robot>

--- a/cob_hardware_config/cob4-7/srdf/cob4-7.srdf
+++ b/cob_hardware_config/cob4-7/srdf/cob4-7.srdf
@@ -1,3 +1,0 @@
-<?xml version="1.0" ?>
-<robot name="cob4-7">
-</robot>

--- a/cob_hardware_config/common/upload_robot.launch
+++ b/cob_hardware_config/common/upload_robot.launch
@@ -1,13 +1,10 @@
 <?xml version="1.0"?>
 <launch>
 
-    <arg name="robot" default="$(optenv ROBOT !!NO_ROBOT_SET!!)"/>
-    <arg name="pkg_hardware_config" default="$(find cob_hardware_config)"/>
+	<arg name="robot" default="$(optenv ROBOT !!NO_ROBOT_SET!!)"/>
+	<arg name="pkg_hardware_config" default="$(find cob_hardware_config)"/>
 
-    <!-- send cob urdf to param server -->
-    <param name="robot_description" command="$(find xacro)/xacro.py '$(arg pkg_hardware_config)/$(arg robot)/urdf/$(arg robot).urdf.xacro'" />
-
-    <!-- The semantic description that corresponds to the URDF -->
-    <param name="robot_description_semantic" textfile="$(arg pkg_hardware_config)/$(arg robot)/srdf/$(arg robot).srdf" />
+	<!-- send cob urdf to param server -->
+	<param name="robot_description" command="$(find xacro)/xacro.py '$(arg pkg_hardware_config)/$(arg robot)/urdf/$(arg robot).urdf.xacro'" />
 
 </launch>

--- a/cob_hardware_config/raw3-1/srdf/raw3-1.srdf
+++ b/cob_hardware_config/raw3-1/srdf/raw3-1.srdf
@@ -1,3 +1,0 @@
-<?xml version="1.0" ?>
-<robot name="raw3-1">
-</robot>

--- a/cob_hardware_config/raw3-2/srdf/raw3-2.srdf
+++ b/cob_hardware_config/raw3-2/srdf/raw3-2.srdf
@@ -1,3 +1,0 @@
-<?xml version="1.0" ?>
-<robot name="raw3-2">
-</robot>

--- a/cob_hardware_config/raw3-3/srdf/raw3-3.srdf
+++ b/cob_hardware_config/raw3-3/srdf/raw3-3.srdf
@@ -1,3 +1,0 @@
-<?xml version="1.0" ?>
-<robot name="raw3-3">
-</robot>

--- a/cob_hardware_config/raw3-4/srdf/raw3-4.srdf
+++ b/cob_hardware_config/raw3-4/srdf/raw3-4.srdf
@@ -1,3 +1,0 @@
-<?xml version="1.0" ?>
-<robot name="raw3-4">
-</robot>

--- a/cob_hardware_config/raw3-5/srdf/raw3-5.srdf
+++ b/cob_hardware_config/raw3-5/srdf/raw3-5.srdf
@@ -1,3 +1,0 @@
-<?xml version="1.0" ?>
-<robot name="raw3-5">
-</robot>

--- a/cob_hardware_config/raw3-6/srdf/raw3-6.srdf
+++ b/cob_hardware_config/raw3-6/srdf/raw3-6.srdf
@@ -1,3 +1,0 @@
-<?xml version="1.0" ?>
-<robot name="raw3-6">
-</robot>


### PR DESCRIPTION
replaces #518 
requires https://github.com/ipa320/cob_manipulation/pull/88

We will keep the moveit_config files separate from ```cob_hardware_config``` files in a dedicated ```cob_moveit_config``` package including only config files (__no moveit launch files__) for easier maintainability.
However, we could move (__with history__) ```cob_moveit_config``` from ```cob_manipulation``` into ```cob_robots``` in order to have all configuration at one place.

We will deal with debugging the functionality of the collision_monitor later, i.e. investigate why wrong collisions are reported and fix model as well as SRDFs...related issue is https://github.com/ipa320/cob_manipulation/issues/89