### PR TITLE
added external sync mode and shared config for head and sensorrring

### DIFF
--- a/cob_bringup/drivers/canopen_402.launch
+++ b/cob_bringup/drivers/canopen_402.launch
@@ -5,11 +5,21 @@
 	<arg name="pkg_hardware_config" default="$(find cob_hardware_config)"/>
 	<arg name="component_name"/>
 	<arg name="can_device"/>
+	<arg name="interval_ms" default="10"/>
+	<arg name="overflow" default="0"/>
+	<arg name="use_external_sync" default="false"/>
+	<arg name="start_external_sync" default="$(arg use_external_sync)"/>
+	
+	<!-- start external sync node if requested -->
+	<node pkg="canopen_chain_node" type="canopen_sync_node" name="sync_$(arg can_device)_$(arg component_name)" output="screen" if="$(arg start_external_sync)">
+		<rosparam subst_value="True">{bus: { device: $(arg can_device) }, sync: { interval_ms: $(arg interval_ms), overflow: $(arg overflow) } }</rosparam>
+	</node>
 
-	<!-- parameters for CANopen node -->
+	<!-- start canopen node -->
 	<node ns="$(arg component_name)" pkg="canopen_motor_node" type="canopen_motor_node" name="driver" output="screen" clear_params="true">
-		<rosparam param="bus/device" subst_value="True">$(arg can_device)</rosparam>
 		<rosparam command="load" file="$(arg pkg_hardware_config)/$(arg robot)/config/$(arg component_name)_driver.yaml"/>
+		<rosparam subst_value="True">{bus: { device: $(arg can_device) }, sync: { interval_ms: $(arg interval_ms), overflow: $(arg overflow) } }</rosparam>
+		<param name="bus/master_allocator" value="canopen::ExternalMaster::Allocator" if="$(arg use_external_sync)"/>
 	</node>
 
 </launch>

--- a/cob_bringup/drivers/canopen_402.launch
+++ b/cob_bringup/drivers/canopen_402.launch
@@ -18,7 +18,8 @@
 	<!-- start canopen node -->
 	<node ns="$(arg component_name)" pkg="canopen_motor_node" type="canopen_motor_node" name="driver" output="screen" clear_params="true">
 		<rosparam command="load" file="$(arg pkg_hardware_config)/$(arg robot)/config/$(arg component_name)_driver.yaml"/>
-		<rosparam subst_value="True">{bus: { device: $(arg can_device) }, sync: { interval_ms: $(arg interval_ms), overflow: $(arg overflow) } }</rosparam>
+		<rosparam subst_value="True">{bus: { device: $(arg can_device) } }</rosparam>
+		<rosparam subst_value="True" if="$(arg use_external_sync)">{sync: { interval_ms: $(arg interval_ms), overflow: $(arg overflow) } }</rosparam>
 		<param name="bus/master_allocator" value="canopen::ExternalMaster::Allocator" if="$(arg use_external_sync)"/>
 	</node>
 

--- a/cob_bringup/package.xml
+++ b/cob_bringup/package.xml
@@ -16,6 +16,7 @@
   <depend>roslaunch</depend>
 
   <exec_depend>camera1394</exec_depend>
+  <exec_depend>canopen_chain_node</exec_depend>
   <exec_depend>canopen_motor_node</exec_depend>
   <exec_depend>cob_android_script_server</exec_depend>
   <exec_depend>cob_base_drive_chain</exec_depend>

--- a/cob_bringup/robots/cob4-10.xml
+++ b/cob_bringup/robots/cob4-10.xml
@@ -123,6 +123,8 @@
 			<arg name="robot" value="$(arg robot)"/>
 			<arg name="component_name" value="sensorring"/>
 			<arg name="can_device" value="can1"/>
+			<arg name="use_external_sync" value="true"/>
+
 			<arg name="cartesian_control" value="false"/>
 			<arg name="sim" value="$(arg sim)"/>
 		</include>
@@ -130,6 +132,9 @@
 			<arg name="robot" value="$(arg robot)"/>
 			<arg name="component_name" value="head"/>
 			<arg name="can_device" value="can1"/>
+			<arg name="use_external_sync" value="true"/>
+			<arg name="start_external_sync" value="false"/>
+
 			<arg name="cartesian_control" value="false"/>
 			<arg name="sim" value="$(arg sim)"/>
 		</include>


### PR DESCRIPTION
This config sets up an external sync (needs https://github.com/ros-industrial/ros_canopen/pull/201) from a shared config.

alternative to #566 