### PR TITLE
[DoNotMerge] concept for unification of hw/sim-independent bringup nodes

### DIFF
--- a/cob_bringup/robots/cob4-1.launch
+++ b/cob_bringup/robots/cob4-1.launch
@@ -3,6 +3,19 @@
 
 	<arg name="env-script" default="$(find cob_bringup)/env.sh"/>
 
+	<!-- start hw-specific nodes, i.e. drivers -->
+	<include file="$(find cob_bringup)/robots/cob4-1_hw.xml" >
+		<!-- cob4-1 is currently a special config setup of cob4-2 hardware -->
+		<arg name="cob4-1-b1" value="cob4-2-b1"/>
+		<arg name="cob4-1-t1" value="cob4-2-t1"/>
+		<arg name="cob4-1-t2" value="cob4-2-t2"/>
+		<arg name="cob4-1-t3" value="cob4-2-t3"/>
+		<arg name="cob4-1-s1" value="cob4-2-s1"/>
+		<arg name="cob4-1-h1" value="cob4-2-h32"/>
+		<arg name="env-script" value="$(arg env-script)"/>
+	</include>
+
+	<!-- start hw-independent nodes, i.e. mid/top-level -->
 	<include file="$(find cob_bringup)/robots/cob4-1.xml" >
 		<!-- cob4-1 is currently a special config setup of cob4-2 hardware -->
 		<arg name="cob4-1-b1" value="cob4-2-b1"/>

--- a/cob_bringup/robots/cob4-1_hw.xml
+++ b/cob_bringup/robots/cob4-1_hw.xml
@@ -12,25 +12,26 @@
     <arg name="env-script" default="$(find cob_bringup)/env.sh"/>
 
     <!-- upload robot description -->
+<!--
     <include file="$(find cob_hardware_config)/common/upload_robot.launch">
         <arg name="robot" value="$(arg robot)"/>
     </include>
+-->
 
     <!-- upload default configuration parameters -->
+<!--
     <include file="$(find cob_default_robot_config)/$(arg robot)/upload_param_$(arg robot).launch"/>
+-->
 
     <group>
         <machine name="cob4-1-b1" address="$(arg cob4-1-b1)" env-loader="$(arg env-script)" default="true" timeout="30"/>
 
-<!--
         <include file="$(find cob_bringup)/tools/pc_monitor.launch">
             <arg name="robot" value="$(arg robot)"/>
             <arg name="pc" value="$(arg cob4-1-b1)"/>
         </include>
--->
 
         <!-- startup hardware -->
-<!--
         <include file="$(find cob_bringup)/drivers/sick_s300.launch">
             <arg name="robot" value="$(arg robot)"/>
             <arg name="name" value="base_laser_front"/>
@@ -43,36 +44,36 @@
             <arg name="robot" value="$(arg robot)"/>
             <arg name="name" value="base_laser_left"/>
         </include>
--->
+<!--
         <include file="$(find cob_bringup)/drivers/scan_unifier.launch">
             <arg name="robot" value="$(arg robot)"/>
         </include>
-<!--
+-->
         <include file="$(find cob_bringup)/drivers/sick_flexisoft.launch">
             <arg name="robot" value="$(arg robot)"/>
         </include>
--->
         <!--include file="$(find cob_bringup)/tools/collision_monitor.launch">
         </include-->
-        <node pkg="rostopic" type="rostopic" args="pub /safety_controller/state_is_valid std_msgs/Bool 'data: true' -r10" name="fake_collission_monitor" output="screen"/>
-
 <!--
+        <node pkg="rostopic" type="rostopic" args="pub /safety_controller/state_is_valid std_msgs/Bool 'data: true' -r10" name="fake_collission_monitor" output="screen"/>
+-->
+
         <include file="$(find cob_bringup)/drivers/canopen_402.launch">
             <arg name="robot" value="$(arg robot)"/>
             <arg name="component_name" value="base"/>
             <arg name="can_device" value="can0"/>
         </include>
--->
+<!--
         <include file="$(find cob_bringup)/controllers/base_controller_plugin.launch">
             <arg name="robot" value="$(arg robot)"/>
         </include>
+-->
 
         <!-- start additional packages -->
-<!--
         <include file="$(find cob_bringup)/drivers/phidgets.launch">
             <arg name="robot" value="$(arg robot)"/>
         </include>
--->
+<!--
         <include file="$(find cob_bringup)/tools/diagnostics_aggregator.launch">
             <arg name="robot" value="$(arg robot)"/>
         </include>
@@ -92,27 +93,31 @@
             <arg name="robot" value="$(arg robot)"/>
             <arg name="component_name" value="light_base"/>
         </include>
+-->
         <!--include file="$(find cob_bringup)/drivers/bms.launch">
             <arg name="robot" value="$(arg robot)" />
         </include-->
-<!--
         <include file="$(find cob_bringup)/drivers/powerstate_phidget.launch">
             <arg name="robot" value="$(arg robot)"/>
         </include>
--->
+<!--
         <include file="$(find cob_bringup)/tools/docker_control.launch">
             <arg name="robot" value="$(arg robot)" />
             <arg name="multi_station" default="true"/>
         </include>
+-->
         <!-- aggregated robot_state_publisher -->
+<!--
         <include file="$(find cob_bringup)/tools/robot_state_publisher.launch">
             <arg name="robot" value="$(arg robot)"/>
         </include>
+-->
     </group>
 
     <group>
         <machine name="cob4-1-t1" address="$(arg cob4-1-t1)" env-loader="$(arg env-script)" default="true" timeout="30"/>
 
+<!--
         <include file="$(find cob_script_server)/launch/script_server.launch"/>
         <include file="$(find cob_bringup)/tools/android.launch">
             <arg name="robot" value="$(arg robot)"/>
@@ -120,21 +125,19 @@
         <include file="$(find cob_bringup)/tools/behavior.launch">
             <arg name="robot" value="$(arg robot)"/>
         </include>
-<!--
+-->
         <include file="$(find cob_bringup)/tools/pc_monitor.launch">
             <arg name="robot" value="$(arg robot)"/>
             <arg name="pc" value="$(arg cob4-1-t1)"/>
         </include>
--->
 
         <!-- startup hardware -->
-<!--
         <include file="$(find cob_bringup)/drivers/canopen_402.launch">
             <arg name="robot" value="$(arg robot)"/>
             <arg name="component_name" value="torso"/>
             <arg name="can_device" value="can0"/>
         </include>
--->
+<!--
         <include file="$(find cob_bringup)/controllers/generic_controller.launch">
             <arg name="robot" value="$(arg robot)"/>
             <arg name="component_name" value="torso"/>
@@ -144,8 +147,8 @@
             <arg name="component_name" value="torso"/>
             <arg name="debug" value="false"/>
         </include>
+-->
 
-		<!-- not yet used in hardware -->
         <!--include file="$(find cob_bringup)/drivers/canopen_402.launch">
             <arg name="robot" value="$(arg robot)"/>
             <arg name="component_name" value="sensorring"/>
@@ -156,7 +159,6 @@
             <arg name="component_name" value="sensorring"/>
         </include-->
 
-		<!-- not yet used in hardware -->
         <!--include file="$(find cob_bringup)/drivers/canopen_402.launch">
             <arg name="robot" value="$(arg robot)"/>
             <arg name="component_name" value="head"/>
@@ -167,14 +169,14 @@
             <arg name="component_name" value="head"/>
         </include-->
 
-<!--
         <include file="$(find cob_bringup)/drivers/openni2.launch">
             <arg name="robot" value="$(arg robot)"/>
             <arg name="name" value="torso_cam3d_right"/>
             <arg name="device_id" value="#1"/>
+            <!--arg name="data_skip" value="1"/-->
             <arg name="num_worker_threads" value="2"/>
         </include>
--->
+<!--
         <include file="$(find cob_bringup)/tools/hz_monitor.launch">
             <arg name="robot" value="$(arg robot)"/>
             <arg name="yaml_name" value="torso_cam3d_right"/>
@@ -190,23 +192,21 @@
             <arg name="robot" value="$(arg robot)"/>
             <arg name="component_name" value="light_torso"/>
         </include>
+-->
     </group>
 
     <group>
         <machine name="cob4-1-t2" address="$(arg cob4-1-t2)" env-loader="$(arg env-script)" default="true" timeout="30"/>
-<!--
         <include file="$(find cob_bringup)/tools/pc_monitor.launch">
             <arg name="robot" value="$(arg robot)"/>
             <arg name="pc" value="$(arg cob4-1-t2)"/>
         </include>
--->
 
-<!--
         <include file="$(find realsense_camera)/launch/r200_nodelet_rgbd.launch">
             <arg name="camera" value="torso_cam3d_down"/>
             <arg name="num_worker_threads" value="2"/>
         </include>
--->
+<!--
         <include file="$(find cob_bringup)/tools/hz_monitor.launch">
             <arg name="robot" value="$(arg robot)"/>
             <arg name="yaml_name" value="torso_cam3d_down"/>
@@ -217,26 +217,25 @@
             <arg name="nodelet_manager" value="torso_cam3d_down_nodelet_manager"/>
             <arg name="start_manager" value="false"/>
         </include>
+-->
     </group>
 
     <group>
         <machine name="cob4-1-t3" address="$(arg cob4-1-t3)" env-loader="$(arg env-script)" default="true" timeout="30"/>
 
-<!--
         <include file="$(find cob_bringup)/tools/pc_monitor.launch">
             <arg name="robot" value="$(arg robot)"/>
             <arg name="pc" value="$(arg cob4-1-t3)"/>
         </include>
--->
 
-<!--
         <include file="$(find cob_bringup)/drivers/openni2.launch">
             <arg name="robot" value="$(arg robot)"/>
             <arg name="name" value="torso_cam3d_left"/>
             <arg name="device_id" value="#1"/>
+            <!--arg name="data_skip" value="1"/-->
             <arg name="num_worker_threads" value="2" />
         </include>
--->
+<!--
         <include file="$(find cob_bringup)/tools/hz_monitor.launch">
             <arg name="robot" value="$(arg robot)"/>
             <arg name="yaml_name" value="torso_cam3d_left"/>
@@ -247,26 +246,24 @@
             <arg name="nodelet_manager" value="torso_cam3d_left_nodelet_manager"/>
             <arg name="start_manager" value="false"/>
         </include>
+-->
     </group>
 
     <group>
         <machine name="cob4-1-s1" address="$(arg cob4-1-s1)" env-loader="$(arg env-script)" default="true" timeout="30"/>
 
-<!--
         <include file="$(find cob_bringup)/tools/pc_monitor.launch">
             <arg name="robot" value="$(arg robot)"/>
             <arg name="pc" value="$(arg cob4-1-s1)"/>
         </include>
--->
 
-<!--
         <include file="$(find cob_bringup)/drivers/openni2.launch">
             <arg name="robot" value="$(arg robot)"/>
             <arg name="name" value="sensorring_cam3d"/>
             <arg name="data_skip" value="3"/>
             <arg name="num_worker_threads" value="2"/>
         </include>
--->
+<!--
         <include file="$(find cob_bringup)/tools/hz_monitor.launch">
             <arg name="robot" value="$(arg robot)"/>
             <arg name="yaml_name" value="sensorring_cam3d"/>
@@ -276,28 +273,28 @@
             <arg name="camera_name" value="sensorring_cam3d"/>
             <arg name="nodelet_manager" value="sensorring_cam3d_nodelet_manager"/>
         </include>
+-->
     </group>
 
     <group>
         <machine name="cob4-1-h1" address="$(arg cob4-1-h1)" env-loader="$(arg env-script)" default="true" timeout="30"/>
 
-<!--
         <include file="$(find cob_bringup)/tools/pc_monitor.launch">
             <arg name="robot" value="$(arg robot)"/>
             <arg name="pc" value="$(arg cob4-1-h1)"/>
         </include>
--->
 
+<!--
         <include file="$(find cob_bringup)/drivers/sound.launch">
             <arg name="robot" value="$(arg robot)"/>
         </include>
+-->
 
-<!--
         <include file="$(find cob_bringup)/drivers/usb_camera_node.launch">
             <arg name="robot" value="$(arg robot)"/>
             <arg name="camera_name" value="head_cam"/>
         </include>
--->
+<!--
         <include file="$(find cob_bringup)/tools/hz_monitor.launch">
             <arg name="robot" value="$(arg robot)"/>
             <arg name="yaml_name" value="head_cam"/>
@@ -308,6 +305,7 @@
             <arg name="colorimage_in" value="/head_cam/image_rect_color"/>
             <arg name="colorimage_out" value="/head_cam_upright/image_rect_color"/>
         </include>
+-->
     </group>
 
     <machine name="cob4-1-b1" address="$(arg cob4-1-b1)" env-loader="$(arg env-script)" default="true" timeout="30"/>

--- a/cob_controller_configuration_gazebo/launch/robots/default_controllers_cob4-1.launch
+++ b/cob_controller_configuration_gazebo/launch/robots/default_controllers_cob4-1.launch
@@ -4,78 +4,93 @@
 	<arg name="robot" default="cob4-1"/>
 
 	<!-- aggregated robot_state_publisher -->
+<!--
 	<include file="$(find cob_bringup)/tools/robot_state_publisher.launch">
 		<arg name="robot" value="$(arg robot)" />
 	</include>
+-->
 
 	<!-- Base -->
 	<!-- simulated driver services -->
 	<node ns="base" pkg="cob_controller_configuration_gazebo" type="gazebo_services.py" name="gazebo_services" cwd="node" respawn="false" output="screen" />
 	<!-- base controllers -->
+<!--
 	<include file="$(find cob_bringup)/controllers/base_controller_plugin.launch">
 		<arg name="robot" value="$(arg robot)"/>
 	</include>
+-->
 	<!-- scanner and scanner-filter -->
-	<include file="$(find cob_bringup)/drivers/laser_scan_filter.launch">
+	<include file="$(find cob_bringup)/drivers/laser_scan_filter.launch"><!-- hidden in driver.launch -->
 		<arg name="robot" value="$(arg robot)"/>
 		<arg name="name" value="base_laser_front"/>
 	</include>
-	<include file="$(find cob_bringup)/drivers/laser_scan_filter.launch">
+	<include file="$(find cob_bringup)/drivers/laser_scan_filter.launch"><!-- hidden in driver.launch -->
 		<arg name="robot" value="$(arg robot)"/>
 		<arg name="name" value="base_laser_left"/>
 	</include>
-	<include file="$(find cob_bringup)/drivers/laser_scan_filter.launch">
+	<include file="$(find cob_bringup)/drivers/laser_scan_filter.launch"><!-- hidden in driver.launch -->
 		<arg name="robot" value="$(arg robot)"/>
 		<arg name="name" value="base_laser_right"/>
 	</include>
+<!--
 	<include file="$(find cob_bringup)/drivers/scan_unifier.launch" >
 		<arg name="robot" value="$(arg robot)" />
 	</include>
+-->
 
-	<include file="$(find cob_bringup)/drivers/relayboard.launch">
+	<include file="$(find cob_bringup)/drivers/relayboard.launch"><!-- simulation option -->
 		<arg name="sim" value="true"/>
 	</include>
 
+<!--
 	<node pkg="rostopic" type="rostopic" args="pub /safety_controller/state_is_valid std_msgs/Bool 'data: true' -r10" name="fake_collission_monitor" output="screen"/>
+-->
 
 	<!-- Torso -->
 	<!-- simulated driver services -->
 	<node ns="torso" pkg="cob_controller_configuration_gazebo" type="gazebo_services.py" name="gazebo_services" cwd="node" respawn="false" output="screen" />
 	<!-- generic controllers -->
+<!--
 	<include file="$(find cob_bringup)/controllers/generic_controller.launch">
 		<arg name="robot" value="$(arg robot)"/>
 		<arg name="component_name" value="torso"/>
 	</include>
+-->
 	<!-- Cartesian controllers -->
+<!--
 	<include file="$(find cob_bringup)/controllers/generic_cartesian_controller.launch">
 		<arg name="robot" value="$(arg robot)"/>
 		<arg name="component_name" value="torso"/>
 	</include>
+-->
 
-	<!-- Head -->
+	<!-- Head --> <!--  not yet in hardware -->
 	<!-- simulated driver services -->
-	<node ns="head" pkg="cob_controller_configuration_gazebo" type="gazebo_services.py" name="gazebo_services" cwd="node" respawn="false" output="screen" />
-	<!-- generic controllers -->
+	<!--node ns="head" pkg="cob_controller_configuration_gazebo" type="gazebo_services.py" name="gazebo_services" cwd="node" respawn="false" output="screen" /-->
+<!--
 	<include file="$(find cob_bringup)/controllers/generic_controller.launch">
 		<arg name="robot" value="$(arg robot)"/>
 		<arg name="component_name" value="head"/>
 	</include>
-	<!-- Cartesian controllers -->
+
 	<include file="$(find cob_bringup)/controllers/generic_cartesian_controller.launch">
 		<arg name="robot" value="$(arg robot)"/>
 		<arg name="component_name" value="head"/>
 	</include>
+-->
 
-	<!-- Sensorring -->
+	<!-- Sensorring --> <!--  not yet in hardware -->
 	<!-- simulated driver services -->
-	<node ns="sensorring" pkg="cob_controller_configuration_gazebo" type="gazebo_services.py" name="gazebo_services" cwd="node" respawn="false" output="screen" />
-	<!-- generic controllers -->
+	<!--node ns="sensorring" pkg="cob_controller_configuration_gazebo" type="gazebo_services.py" name="gazebo_services" cwd="node" respawn="false" output="screen" /-->
+<!--
 	<include file="$(find cob_bringup)/controllers/generic_controller.launch">
 		<arg name="robot" value="$(arg robot)"/>
 		<arg name="component_name" value="sensorring"/>
 	</include>
+-->
 
 	<!-- camera nodelets -->
+<!--
 	<include file="$(find cob_bringup)/drivers/image_flip.launch">
 		<arg name="robot" value="$(arg robot)"/>
 		<arg name="camera_name" value="torso_cam3d_left"/>
@@ -97,15 +112,17 @@
 		<arg name="colorimage_in" value="/head_cam/image_rect_color"/>
 		<arg name="colorimage_out" value="/head_cam_upright/image_raw"/>
 	</include>
+-->
 	<node name="image_proc" pkg="image_proc" type="image_proc" ns="head_cam"/>
 
 	<!-- start additional components -->
+<!--
 	<include file="$(find cob_bringup)/drivers/sound.launch" >
 		<arg name="robot" value="$(arg robot)"/>
 	</include>
-	<!--include file="$(find cob_bringup)/tools/base_collision_observer.launch" >
+	<include file="$(find cob_bringup)/tools/base_collision_observer.launch" >
 		<arg name="robot" value="$(arg robot)"/>
-	</include-->
+	</include>
 	<include file="$(find cob_bringup)/tools/diagnostics_aggregator.launch" >
 		<arg name="robot" value="$(arg robot)"/>
 	</include>
@@ -115,8 +132,13 @@
 	</include>
 
 	<include file="$(find cob_script_server)/launch/script_server.launch" />
+-->
 	
 	<node name="fake_monitor" pkg="cob_controller_configuration_gazebo" type="fake_monitoring.py" args="--diag-hostnames='light, safety, base_laser_front, base_laser_right, base_laser_left, -b1, -t1, -t2, -t3, -s1, -h32, torso_cam3d_right, torso_cam3d_left, head_cam, sensorring_cam3d, torso/driver, torso_cam3d_down, base/driver, joystick'"/>
-	
+
+
+
+	<!-- start sim-independent nodes, i.e. mid/top-level -->
+	<include file="$(find cob_bringup)/robots/cob4-1.xml" />
 
 </launch>

--- a/cob_hardware_config/cob4-1/urdf/cob4-1.urdf.xacro
+++ b/cob_hardware_config/cob4-1/urdf/cob4-1.urdf.xacro
@@ -16,10 +16,10 @@
   <!-- torso -->
   <xacro:include filename="$(find cob_description)/urdf/cob4_torso/torso_2dof.urdf.xacro" />
 
-  <!-- head -->
-  <xacro:include filename="$(find cob_description)/urdf/cob4_head/head.urdf.xacro" />
+  <!-- head --> <!--  not yet in hardware -->
+  <xacro:include filename="$(find cob_description)/urdf/cob4_head/head_static.urdf.xacro" />
 
-  <!-- sensorring -->
+  <!-- sensorring --> <!--  not yet in hardware -->
   <xacro:include filename="$(find cob_description)/urdf/cob4_sensorring/sensorring_asus.urdf.xacro" />
 
   <!-- composition of the robot -->
@@ -44,21 +44,25 @@
   <xacro:head name="head" parent="torso_3_link">
     <origin xyz="${head_x} ${head_y} ${head_z}" rpy="${head_roll} ${head_pitch} ${head_yaw}" />
   </xacro:head>
+<!-- currently not used in hardware
   <gazebo>
     <plugin name="ros_control" filename="libhwi_switch_gazebo_ros_control.so">
       <robotNamespace>head</robotNamespace>
       <filterJointsParam>joint_names</filterJointsParam>
     </plugin>
   </gazebo>
+-->
 
   <xacro:sensorring name="sensorring" parent="head_3_link">
     <origin xyz="${sensorring_x} ${sensorring_y} ${sensorring_z}" rpy="${sensorring_roll} ${sensorring_pitch} ${sensorring_yaw}" />
   </xacro:sensorring>
+<!-- currently not used in hardware
   <gazebo>
     <plugin name="ros_control" filename="libhwi_switch_gazebo_ros_control.so">
       <robotNamespace>sensorring</robotNamespace>
       <filterJointsParam>joint_names</filterJointsParam>
     </plugin>
   </gazebo>
+-->
 
 </robot>


### PR DESCRIPTION
__This PR is (currently) not meant to be merged!__

I opened it to throw in a concept to be discussed with which we could achieve a further unification/harmonization between ```cob_bringup``` (i.e. hardware) and ```cob_bringup_sim``` (simulation).

The main idea is to extract common parts of ```cob_bringup/cobX-X.xml``` and ```default_controllers_cobX-X.launch``` (i.e. parts that occur in both of these files) into a launch file that - __identically__ - will be used by both cob_bringup and cob_bringup_sim!

What's left in ```cob_bringup/cobX-X.xml``` is hardware-specific (i.e. drivers) and will be named ```cob_bringup/cobX-X_hw.xml```. What's left in ```default_controllers_cobX-X.launch``` is simulation-specific and could be moved into a launch file in cob_bringup_sim (creating a similar structure analog to cob_bringup using cobX-X sub-folders).

In the end, the package ```cob_controller_configuration_gazebo``` will become obsolete and could be removed from cob_robots (the remaining scripts will be moved to cob_simulation).

Goal of this splitting would be to move as much into the common cobX-X.xml file which would guarantee hw-/sim-behavior (i.e. topics, actions, services) as similar as possible. Also, we would not need to remember to adjust simulation when adding something in hardware and vice-versa...

The whole effort can be seen as part of #437

@ipa-fmw @ipa-nhg @ipa-mdl @ipa-mig @ipa-bnm what do you think?
Is the intended concept clear? Don't hesitate to ask questions and discuss!

In the PR I only commented parts instead of removing.
What is commented in cobX-X_hw.xml is hw-independent and can be moved to cobX-X.xml.
What is commented in cobX-X.xml is hw-specific and stays in cobX-X_hw.xml
