### PR TITLE
remove obsolete envlist from tests

### DIFF
--- a/cob_bringup/CMakeLists.txt
+++ b/cob_bringup/CMakeLists.txt
@@ -25,23 +25,11 @@ set(robotlist
   raw3-6
 )
 
-set(envlist
-  empty
-  ipa-kitchen
-  ipa-apartment
-  ipa-factory
-)
-
 ### TEST ###
 if(CATKIN_ENABLE_TESTING)
   foreach(robot ${robotlist})
-    foreach(env ${envlist})
-      message("testing for robot: ${robot} in env: ${env}")
-      #roslaunch_add_file_check(tools robot:=${robot} robot_env:=${env})
-      #roslaunch_add_file_check(tools ROBOT=${robot} ROBOT_ENV=${env})
-      #roslaunch_add_file_check(robots/${robot}.xml robot_env:=${env})
-      roslaunch_add_file_check(robots/${robot}.xml ROBOT_ENV=${env})
-    endforeach()
+    message("testing for robot: ${robot}")
+    roslaunch_add_file_check(robots/${robot}.xml)
   endforeach()
 endif()
 


### PR DESCRIPTION
as we are testing ```${robot}.xml``` which is independent from ```ROBOT_ENV``` we can remove the for-loop over ```envlist```....```ipa-factory``` is no longer an available env anyway