### PR TITLE
Enable collision monitor

### DIFF
--- a/cob_bringup/robots/cob4-2.xml
+++ b/cob_bringup/robots/cob4-2.xml
@@ -79,8 +79,7 @@
 		<include file="$(find cob_bringup)/tools/base_collision_observer.launch">
 			<arg name="robot" value="$(arg robot)"/>
 		</include>
-		<!-- <include file="$(find cob_bringup)/tools/collision_monitor.launch"> -->
-		<node pkg="rostopic" type="rostopic" args="pub /safety_controller/state_is_valid std_msgs/Bool 'data: true' -r10" name="fake_collission_monitor" output="screen"/>
+		<include file="$(find cob_bringup)/tools/collision_monitor.launch"/>
 
 		<include file="$(find cob_bringup)/tools/diagnostics_aggregator.launch">
 			<arg name="robot" value="$(arg robot)"/>

--- a/cob_bringup/robots/cob4-5.xml
+++ b/cob_bringup/robots/cob4-5.xml
@@ -79,8 +79,7 @@
 		<include file="$(find cob_bringup)/tools/base_collision_observer.launch">
 			<arg name="robot" value="$(arg robot)"/>
 		</include>
-		<!-- <include file="$(find cob_bringup)/tools/collision_monitor.launch"> -->
-		<node pkg="rostopic" type="rostopic" args="pub /safety_controller/state_is_valid std_msgs/Bool 'data: true' -r10" name="fake_collission_monitor" output="screen"/>
+		<include file="$(find cob_bringup)/tools/collision_monitor.launch"/>
 
 		<include file="$(find cob_bringup)/tools/diagnostics_aggregator.launch">
 			<arg name="robot" value="$(arg robot)"/>

--- a/cob_bringup/robots/cob4-7.xml
+++ b/cob_bringup/robots/cob4-7.xml
@@ -79,8 +79,7 @@
 		<include file="$(find cob_bringup)/tools/base_collision_observer.launch">
 			<arg name="robot" value="$(arg robot)"/>
 		</include>
-		<!-- <include file="$(find cob_bringup)/tools/collision_monitor.launch"> -->
-		<node pkg="rostopic" type="rostopic" args="pub /safety_controller/state_is_valid std_msgs/Bool 'data: true' -r10" name="fake_collission_monitor" output="screen"/>
+		<include file="$(find cob_bringup)/tools/collision_monitor.launch"/>
 
 		<include file="$(find cob_bringup)/tools/diagnostics_aggregator.launch">
 			<arg name="robot" value="$(arg robot)"/>


### PR DESCRIPTION
Now that torso mesh is fixed and collision matrix is updated, we could test the collision_monitor again...
Please test on robot before merging