### PR TITLE
use xacro --inorder + move gazebo_ros_control plugin to component

### DIFF
--- a/cob_hardware_config/cob4-10/urdf/cob4-10.urdf.xacro
+++ b/cob_hardware_config/cob4-10/urdf/cob4-10.urdf.xacro
@@ -29,12 +29,6 @@
 
   <!-- composition of the robot -->
   <xacro:base name="base" use_old_joint_names="false"/>
-  <gazebo>
-    <plugin name="ros_control" filename="libhwi_switch_gazebo_ros_control.so">
-      <robotNamespace>base</robotNamespace>
-      <filterJointsParam>joint_names</filterJointsParam>
-    </plugin>
-  </gazebo>
 
   <xacro:torso name="torso" parent="base_link" dof1="false" dof2="true" dof3="true">
     <origin xyz="${torso_x} ${torso_y} ${torso_z}" rpy="${torso_roll} ${torso_pitch} ${torso_yaw}" />
@@ -51,12 +45,6 @@
   <xacro:realsense name="torso_cam3d_down" ros_topic="torso_cam3d_down" parent="torso_3_link">
     <origin xyz="${torso_cam3d_down_x} ${torso_cam3d_down_y} ${torso_cam3d_down_z}" rpy="${torso_cam3d_down_roll} ${torso_cam3d_down_pitch} ${torso_cam3d_down_yaw}" />
   </xacro:realsense>
-  <gazebo>
-    <plugin name="ros_control" filename="libhwi_switch_gazebo_ros_control.so">
-      <robotNamespace>torso</robotNamespace>
-      <filterJointsParam>joint_names</filterJointsParam>
-    </plugin>
-  </gazebo>
 
   <xacro:head name="head" parent="torso_3_link" dof1="true" dof2="true" dof3="true">
     <origin xyz="${head_x} ${head_y} ${head_z}" rpy="${head_roll} ${head_pitch} ${head_yaw}" />
@@ -64,12 +52,6 @@
   <xacro:usb_cam name="head_cam" parent="head_3_link" ros_topic="head_cam">
     <origin xyz="${head_cam_x} ${head_cam_y} ${head_cam_z}" rpy="${head_cam_roll} ${head_cam_pitch} ${head_cam_yaw}" />
   </xacro:usb_cam>
-  <gazebo>
-    <plugin name="ros_control" filename="libhwi_switch_gazebo_ros_control.so">
-      <robotNamespace>head</robotNamespace>
-      <filterJointsParam>joint_names</filterJointsParam>
-    </plugin>
-  </gazebo>
 
   <xacro:sensorring name="sensorring" parent="head_3_link" active="true">
     <origin xyz="${sensorring_x} ${sensorring_y} ${sensorring_z}" rpy="${sensorring_roll} ${sensorring_pitch} ${sensorring_yaw}" />
@@ -77,11 +59,5 @@
   <xacro:cob_kinect_v0 name="sensorring_cam3d" ros_topic="sensorring_cam3d" parent="sensorring_link">
     <origin xyz="${sensorring_cam3d_x} ${sensorring_cam3d_y} ${sensorring_cam3d_z}" rpy="${sensorring_cam3d_roll} ${sensorring_cam3d_pitch} ${sensorring_cam3d_yaw}" />
   </xacro:cob_kinect_v0>
-  <gazebo>
-    <plugin name="ros_control" filename="libhwi_switch_gazebo_ros_control.so">
-      <robotNamespace>sensorring</robotNamespace>
-      <filterJointsParam>joint_names</filterJointsParam>
-    </plugin>
-  </gazebo>
 
 </robot>

--- a/cob_hardware_config/cob4-2/urdf/cob4-2.urdf.xacro
+++ b/cob_hardware_config/cob4-2/urdf/cob4-2.urdf.xacro
@@ -29,12 +29,6 @@
 
   <!-- composition of the robot -->
   <xacro:base name="base" use_old_joint_names="false"/>
-  <gazebo>
-    <plugin name="ros_control" filename="libhwi_switch_gazebo_ros_control.so">
-      <robotNamespace>base</robotNamespace>
-      <filterJointsParam>joint_names</filterJointsParam>
-    </plugin>
-  </gazebo>
 
   <xacro:torso name="torso" parent="base_link" dof1="false" dof2="true" dof3="true">
     <origin xyz="${torso_x} ${torso_y} ${torso_z}" rpy="${torso_roll} ${torso_pitch} ${torso_yaw}" />
@@ -51,12 +45,6 @@
   <xacro:realsense name="torso_cam3d_down" ros_topic="torso_cam3d_down" parent="torso_3_link">
     <origin xyz="${torso_cam3d_down_x} ${torso_cam3d_down_y} ${torso_cam3d_down_z}" rpy="${torso_cam3d_down_roll} ${torso_cam3d_down_pitch} ${torso_cam3d_down_yaw}" />
   </xacro:realsense>
-  <gazebo>
-    <plugin name="ros_control" filename="libhwi_switch_gazebo_ros_control.so">
-      <robotNamespace>torso</robotNamespace>
-      <filterJointsParam>joint_names</filterJointsParam>
-    </plugin>
-  </gazebo>
 
   <xacro:head name="head" parent="torso_3_link" dof1="true" dof2="true" dof3="true">
     <origin xyz="${head_x} ${head_y} ${head_z}" rpy="${head_roll} ${head_pitch} ${head_yaw}" />
@@ -64,12 +52,6 @@
   <xacro:usb_cam name="head_cam" parent="head_3_link" ros_topic="head_cam">
     <origin xyz="${head_cam_x} ${head_cam_y} ${head_cam_z}" rpy="${head_cam_roll} ${head_cam_pitch} ${head_cam_yaw}" />
   </xacro:usb_cam>
-  <gazebo>
-    <plugin name="ros_control" filename="libhwi_switch_gazebo_ros_control.so">
-      <robotNamespace>head</robotNamespace>
-      <filterJointsParam>joint_names</filterJointsParam>
-    </plugin>
-  </gazebo>
 
   <xacro:sensorring name="sensorring" parent="head_3_link" active="true">
     <origin xyz="${sensorring_x} ${sensorring_y} ${sensorring_z}" rpy="${sensorring_roll} ${sensorring_pitch} ${sensorring_yaw}" />
@@ -77,11 +59,5 @@
   <xacro:cob_kinect_v0 name="sensorring_cam3d" ros_topic="sensorring_cam3d" parent="sensorring_link">
     <origin xyz="${sensorring_cam3d_x} ${sensorring_cam3d_y} ${sensorring_cam3d_z}" rpy="${sensorring_cam3d_roll} ${sensorring_cam3d_pitch} ${sensorring_cam3d_yaw}" />
   </xacro:cob_kinect_v0>
-  <gazebo>
-    <plugin name="ros_control" filename="libhwi_switch_gazebo_ros_control.so">
-      <robotNamespace>sensorring</robotNamespace>
-      <filterJointsParam>joint_names</filterJointsParam>
-    </plugin>
-  </gazebo>
 
 </robot>

--- a/cob_hardware_config/cob4-3/urdf/cob4-3.urdf.xacro
+++ b/cob_hardware_config/cob4-3/urdf/cob4-3.urdf.xacro
@@ -15,11 +15,5 @@
 
   <!-- composition of the robot -->
   <xacro:base name="base" use_old_joint_names="false"/>
-  <gazebo>
-    <plugin name="ros_control" filename="libhwi_switch_gazebo_ros_control.so">
-      <robotNamespace>base</robotNamespace>
-      <filterJointsParam>joint_names</filterJointsParam>
-    </plugin>
-  </gazebo>
 
 </robot>

--- a/cob_hardware_config/cob4-4/urdf/cob4-4.urdf.xacro
+++ b/cob_hardware_config/cob4-4/urdf/cob4-4.urdf.xacro
@@ -15,11 +15,5 @@
 
   <!-- composition of the robot -->
   <xacro:base name="base" use_old_joint_names="false"/>
-  <gazebo>
-    <plugin name="ros_control" filename="libhwi_switch_gazebo_ros_control.so">
-      <robotNamespace>base</robotNamespace>
-      <filterJointsParam>joint_names</filterJointsParam>
-    </plugin>
-  </gazebo>
 
 </robot>

--- a/cob_hardware_config/cob4-5/urdf/cob4-5.urdf.xacro
+++ b/cob_hardware_config/cob4-5/urdf/cob4-5.urdf.xacro
@@ -36,12 +36,6 @@
 
   <!-- composition of the robot -->
   <xacro:base name="base" use_old_joint_names="false"/>
-  <gazebo>
-    <plugin name="ros_control" filename="libhwi_switch_gazebo_ros_control.so">
-      <robotNamespace>base</robotNamespace>
-      <filterJointsParam>joint_names</filterJointsParam>
-    </plugin>
-  </gazebo>
 
   <xacro:torso name="torso" parent="base_link" dof1="false" dof2="false" dof3="false">
     <origin xyz="${torso_x} ${torso_y} ${torso_z}" rpy="${torso_roll} ${torso_pitch} ${torso_yaw}" />
@@ -76,51 +70,21 @@
   <xacro:cob_kinect_v0 name="sensorring_cam3d_back" ros_topic="sensorring_cam3d_back" parent="sensorring_link">
     <origin xyz="${sensorring_cam3d_back_x} ${sensorring_cam3d_back_y} ${sensorring_cam3d_back_z}" rpy="${sensorring_cam3d_back_roll} ${sensorring_cam3d_back_pitch} ${sensorring_cam3d_back_yaw}" />
   </xacro:cob_kinect_v0>
-  <gazebo>
-    <plugin name="ros_control" filename="libhwi_switch_gazebo_ros_control.so">
-      <robotNamespace>sensorring</robotNamespace>
-      <filterJointsParam>joint_names</filterJointsParam>
-    </plugin>
-  </gazebo>
 
   <xacro:schunk_lwa4p_extended name="arm_right" parent="torso_3_link" has_podest="false">
     <origin xyz="${arm_right_x} ${arm_right_y} ${arm_right_z}" rpy="${arm_right_roll} ${arm_right_pitch} ${arm_right_yaw}" />
   </xacro:schunk_lwa4p_extended>
-  <gazebo>
-    <plugin name="ros_control" filename="libhwi_switch_gazebo_ros_control.so">
-      <robotNamespace>arm_right</robotNamespace>
-      <filterJointsParam>joint_names</filterJointsParam>
-    </plugin>
-  </gazebo>
 
   <xacro:schunk_lwa4p_extended name="arm_left" parent="torso_3_link" has_podest="false">
     <origin xyz="${arm_left_x} ${arm_left_y} ${arm_left_z}" rpy="${arm_left_roll} ${arm_left_pitch} ${arm_left_yaw}" />
   </xacro:schunk_lwa4p_extended>
-  <gazebo>
-    <plugin name="ros_control" filename="libhwi_switch_gazebo_ros_control.so">
-      <robotNamespace>arm_left</robotNamespace>
-      <filterJointsParam>joint_names</filterJointsParam>
-    </plugin>
-  </gazebo>
 
   <xacro:gripper name="gripper_right" parent="arm_right_7_link">
     <origin xyz="${gripper_right_x} ${gripper_right_y} ${gripper_right_z}" rpy="${gripper_right_roll} ${gripper_right_pitch} ${gripper_right_yaw}" />
   </xacro:gripper>
-  <gazebo>
-    <plugin name="ros_control" filename="libhwi_switch_gazebo_ros_control.so">
-      <robotNamespace>gripper_right</robotNamespace>
-      <filterJointsParam>joint_names</filterJointsParam>
-    </plugin>
-  </gazebo>
 
   <xacro:gripper name="gripper_left" parent="arm_left_7_link">
     <origin xyz="${gripper_left_x} ${gripper_left_y} ${gripper_left_z}" rpy="${gripper_left_roll} ${gripper_left_pitch} ${gripper_left_yaw}" />
   </xacro:gripper>
-  <gazebo>
-    <plugin name="ros_control" filename="libhwi_switch_gazebo_ros_control.so">
-      <robotNamespace>gripper_left</robotNamespace>
-      <filterJointsParam>joint_names</filterJointsParam>
-    </plugin>
-  </gazebo>
 
 </robot>

--- a/cob_hardware_config/cob4-6/urdf/cob4-6.urdf.xacro
+++ b/cob_hardware_config/cob4-6/urdf/cob4-6.urdf.xacro
@@ -15,11 +15,5 @@
 
   <!-- composition of the robot -->
   <xacro:base name="base" use_old_joint_names="false"/>
-  <gazebo>
-    <plugin name="ros_control" filename="libhwi_switch_gazebo_ros_control.so">
-      <robotNamespace>base</robotNamespace>
-      <filterJointsParam>joint_names</filterJointsParam>
-    </plugin>
-  </gazebo>
 
 </robot>

--- a/cob_hardware_config/cob4-7/urdf/cob4-7.urdf.xacro
+++ b/cob_hardware_config/cob4-7/urdf/cob4-7.urdf.xacro
@@ -32,12 +32,6 @@
 
   <!-- composition of the robot -->
   <xacro:base name="base" use_old_joint_names="false"/>
-  <gazebo>
-    <plugin name="ros_control" filename="libhwi_switch_gazebo_ros_control.so">
-      <robotNamespace>base</robotNamespace>
-      <filterJointsParam>joint_names</filterJointsParam>
-    </plugin>
-  </gazebo>
 
   <xacro:torso name="torso" parent="base_link" dof1="false" dof2="true" dof3="true">
     <origin xyz="${torso_x} ${torso_y} ${torso_z}" rpy="${torso_roll} ${torso_pitch} ${torso_yaw}" />
@@ -54,32 +48,14 @@
   <xacro:realsense name="torso_cam3d_down" ros_topic="torso_cam3d_down" parent="torso_3_link">
     <origin xyz="${torso_cam3d_down_x} ${torso_cam3d_down_y} ${torso_cam3d_down_z}" rpy="${torso_cam3d_down_roll} ${torso_cam3d_down_pitch} ${torso_cam3d_down_yaw}" />
   </xacro:realsense>
-  <gazebo>
-    <plugin name="ros_control" filename="libhwi_switch_gazebo_ros_control.so">
-      <robotNamespace>torso</robotNamespace>
-      <filterJointsParam>joint_names</filterJointsParam>
-    </plugin>
-  </gazebo>
 
   <xacro:schunk_lwa4p_extended name="arm_right" parent="torso_3_link" has_podest="false">
     <origin xyz="${arm_right_x} ${arm_right_y} ${arm_right_z}" rpy="${arm_right_roll} ${arm_right_pitch} ${arm_right_yaw}" />
   </xacro:schunk_lwa4p_extended>
-  <gazebo>
-    <plugin name="ros_control" filename="libhwi_switch_gazebo_ros_control.so">
-      <robotNamespace>arm_right</robotNamespace>
-      <filterJointsParam>joint_names</filterJointsParam>
-    </plugin>
-  </gazebo>
 
   <xacro:schunk_lwa4p_extended name="arm_left" parent="torso_3_link" has_podest="false">
     <origin xyz="${arm_left_x} ${arm_left_y} ${arm_left_z}" rpy="${arm_left_roll} ${arm_left_pitch} ${arm_left_yaw}" />
   </xacro:schunk_lwa4p_extended>
-  <gazebo>
-    <plugin name="ros_control" filename="libhwi_switch_gazebo_ros_control.so">
-      <robotNamespace>arm_left</robotNamespace>
-      <filterJointsParam>joint_names</filterJointsParam>
-    </plugin>
-  </gazebo>
 
   <xacro:head name="head" parent="torso_3_link" dof1="true" dof2="true" dof3="true">
     <origin xyz="${head_x} ${head_y} ${head_z}" rpy="${head_roll} ${head_pitch} ${head_yaw}" />
@@ -87,12 +63,6 @@
   <xacro:usb_cam name="head_cam" parent="head_3_link" ros_topic="head_cam">
     <origin xyz="${head_cam_x} ${head_cam_y} ${head_cam_z}" rpy="${head_cam_roll} ${head_cam_pitch} ${head_cam_yaw}" />
   </xacro:usb_cam>
-  <gazebo>
-    <plugin name="ros_control" filename="libhwi_switch_gazebo_ros_control.so">
-      <robotNamespace>head</robotNamespace>
-      <filterJointsParam>joint_names</filterJointsParam>
-    </plugin>
-  </gazebo>
 
   <xacro:sensorring name="sensorring" parent="head_3_link" active="true">
     <origin xyz="${sensorring_x} ${sensorring_y} ${sensorring_z}" rpy="${sensorring_roll} ${sensorring_pitch} ${sensorring_yaw}" />
@@ -100,11 +70,5 @@
   <xacro:cob_kinect_v0 name="sensorring_cam3d" ros_topic="sensorring_cam3d" parent="sensorring_link">
     <origin xyz="${sensorring_cam3d_x} ${sensorring_cam3d_y} ${sensorring_cam3d_z}" rpy="${sensorring_cam3d_roll} ${sensorring_cam3d_pitch} ${sensorring_cam3d_yaw}" />
   </xacro:cob_kinect_v0>
-  <gazebo>
-    <plugin name="ros_control" filename="libhwi_switch_gazebo_ros_control.so">
-      <robotNamespace>sensorring</robotNamespace>
-      <filterJointsParam>joint_names</filterJointsParam>
-    </plugin>
-  </gazebo>
 
 </robot>

--- a/cob_hardware_config/common/upload_robot.launch
+++ b/cob_hardware_config/common/upload_robot.launch
@@ -5,6 +5,6 @@
 	<arg name="pkg_hardware_config" default="$(find cob_hardware_config)"/>
 
 	<!-- send cob urdf to param server -->
-	<param name="robot_description" command="$(find xacro)/xacro.py '$(arg pkg_hardware_config)/$(arg robot)/urdf/$(arg robot).urdf.xacro'" />
+	<param name="robot_description" command="$(find xacro)/xacro --inorder '$(arg pkg_hardware_config)/$(arg robot)/urdf/$(arg robot).urdf.xacro'" />
 
 </launch>

--- a/cob_hardware_config/raw3-1/urdf/raw3-1.urdf.xacro
+++ b/cob_hardware_config/raw3-1/urdf/raw3-1.urdf.xacro
@@ -29,12 +29,6 @@
 
   <!-- composition of the robot -->
   <xacro:raw_base name="base"/>
-  <gazebo>
-    <plugin name="ros_control" filename="libhwi_switch_gazebo_ros_control.so">
-      <robotNamespace>base</robotNamespace>
-      <filterJointsParam>joint_names</filterJointsParam>
-    </plugin>
-  </gazebo>
 
   <xacro:tower_asymetric name="tower" parent="base_link">
     <origin xyz="${tower_x} ${tower_y} ${tower_z}" rpy="${tower_roll} ${tower_pitch} ${tower_yaw}" />
@@ -43,12 +37,6 @@
   <xacro:raw_torso name="torso" parent="base_link">
     <origin xyz="${torso_x} ${torso_y} ${torso_z}" rpy="${torso_roll} ${torso_pitch} ${torso_yaw}" />
   </xacro:raw_torso>
-  <gazebo>
-    <plugin name="ros_control" filename="libhwi_switch_gazebo_ros_control.so">
-      <robotNamespace>torso</robotNamespace>
-      <filterJointsParam>joint_names</filterJointsParam>
-    </plugin>
-  </gazebo>
 
   <xacro:raw_head name="head" parent="torso_2_link">
     <origin xyz="${head_x} ${head_y} ${head_z}" rpy="${head_roll} ${head_pitch} ${head_yaw}" />
@@ -58,12 +46,6 @@
   <xacro:ur10 name="arm" parent="base_link">
     <origin xyz="${arm_x} ${arm_y} ${arm_z}" rpy="${arm_roll} ${arm_pitch} ${arm_yaw}" />
   </xacro:ur10>
-  <gazebo>
-    <plugin name="ros_control" filename="libhwi_switch_gazebo_ros_control.so">
-      <robotNamespace>arm</robotNamespace>
-      <filterJointsParam>joint_names</filterJointsParam>
-    </plugin>
-  </gazebo>
 
   <xacro:raw_boxgripper name="gripper" parent="arm_ee_link">
     <origin xyz="${gripper_x} ${gripper_y} ${gripper_z}" rpy="${gripper_roll} ${gripper_pitch} ${gripper_yaw}" />

--- a/cob_hardware_config/raw3-3/urdf/raw3-3.urdf.xacro
+++ b/cob_hardware_config/raw3-3/urdf/raw3-3.urdf.xacro
@@ -18,12 +18,6 @@
 
   <!-- composition of the robot -->
   <xacro:raw_base name="base"/>
-  <gazebo>
-    <plugin name="ros_control" filename="libhwi_switch_gazebo_ros_control.so">
-      <robotNamespace>base</robotNamespace>
-      <filterJointsParam>joint_names</filterJointsParam>
-    </plugin>
-  </gazebo>
 
 <!--
   <xacro:tower_symetric name="tower" parent="base_link">
@@ -31,24 +25,23 @@
   </xacro:tower_symetric>
 -->
 
-
   <!-- scan top mount -->
-    <joint name="base_laser_top_joint" type="fixed" >
-      <origin xyz="0.28 0.0 0.885" rpy="0.0 0.0 0.0" />
-      <parent link="base_link" />
-      <child link="base_laser_top_link" />
-    </joint>
+  <joint name="base_laser_top_joint" type="fixed" >
+    <origin xyz="0.28 0.0 0.885" rpy="0.0 0.0 0.0" />
+    <parent link="base_link" />
+    <child link="base_laser_top_link" />
+  </joint>
 
-    <link name="base_laser_top_link">
+  <link name="base_laser_top_link">
     <xacro:default_inertial />
     <visual>
       <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0" />
       <geometry>
-      <box size="0.10 0.03 0.03" />
+        <box size="0.10 0.03 0.03" />
       </geometry>
       <material name="IPA/Black" />
     </visual>
-    </link>
+  </link>
   <!-- END: scan top mount -->
 
 </robot>

--- a/cob_hardware_config/raw3-5/urdf/raw3-5.urdf.xacro
+++ b/cob_hardware_config/raw3-5/urdf/raw3-5.urdf.xacro
@@ -14,12 +14,5 @@
 
   <!-- composition of the robot -->
   <xacro:raw_base name="base"/>
-  <gazebo>
-    <plugin name="ros_control" filename="libhwi_switch_gazebo_ros_control.so">
-      <robotNamespace>base</robotNamespace>
-      <filterJointsParam>joint_names</filterJointsParam>
-    </plugin>
-  </gazebo>
-
 
 </robot>


### PR DESCRIPTION
These PR-set allows to use latest [xacro](http://wiki.ros.org/action/fullsearch/xacro), i.e. e.g. conditional blocks

Also moves the per-component gazebo_ros_control plugin from the robot to the component. This is another step towards the robot-module-component structure we are tackling...

Related PRs are:
 - https://github.com/ipa320/cob_common/pull/208
 - https://github.com/ipa320/cob_manipulation/pull/97
 - https://github.com/ipa320/cob_control/pull/130
 - https://github.com/ipa320/schunk_robots/pull/72
 - https://github.com/ipa320/schunk_modular_robotics/pull/181
 - https://github.com/ipa320/cob_simulation/pull/136