### PR TITLE
[kinetic] removed unused image_proc node

### DIFF
--- a/cob_bringup/drivers/usb_camera_node.launch
+++ b/cob_bringup/drivers/usb_camera_node.launch
@@ -14,6 +14,4 @@
 		<param name="camera_name" value="$(arg camera_name)"/>
 		<param name="camera_info_url" value="package://cob_calibration_data/$(arg robot)/calibration/cameras/$(arg camera_name).yaml"/>
 	</node>
-	<node name="image_proc" pkg="image_proc" type="image_proc" ns="$(arg camera_name)"/>
-
 </launch>

--- a/cob_bringup/package.xml
+++ b/cob_bringup/package.xml
@@ -63,7 +63,6 @@
   <exec_depend>controller_manager</exec_depend>
   <exec_depend>costmap_2d</exec_depend>
   <exec_depend>diagnostic_aggregator</exec_depend>
-  <exec_depend>image_proc</exec_depend>
   <exec_depend>joint_state_controller</exec_depend>
   <exec_depend>joint_state_publisher</exec_depend>
   <exec_depend>joint_trajectory_controller</exec_depend>


### PR DESCRIPTION
On kinetic image_pipeline is already publishing rectified images. So no need to start extra node for rectification.

See this PR https://github.com/ipa320/cob_robots/pull/607