### PR TITLE
add realsense static frames for simulation

### DIFF
--- a/cob_bringup/components/cam3d_r200_rgbd.launch
+++ b/cob_bringup/components/cam3d_r200_rgbd.launch
@@ -21,4 +21,20 @@
 		<arg name="nodelet_manager" value="$(arg name)_nodelet_manager"/>
 		<arg name="start_manager" value="$(arg start_manager)"/>
 	</include>
+
+
+	<!-- static frames broadcasted by camera driver -->
+	<group if="$(arg sim)">
+		<node pkg="tf2_ros" type="static_transform_publisher" name="stp_rgb_frame" args="0.0 0.0 0.0 0.0 0.0 0.0 1.0 /$(arg name)_link /$(arg name)_rgb_frame"/>
+		<node pkg="tf2_ros" type="static_transform_publisher" name="stp_rgb_optical_frame" args="0.0 0.0 0.0 -0.5 0.5 -0.5 0.5 /$(arg name)_rgb_frame /$(arg name)_rgb_optical_frame"/>
+
+		<node pkg="tf2_ros" type="static_transform_publisher" name="stp_depth_frame" args="0.0 0.059 0.0 0.0 0.0 0.0 1.0 /$(arg name)_link /$(arg name)_depth_frame"/>
+		<node pkg="tf2_ros" type="static_transform_publisher" name="stp_depth_optical_frame" args="0.0 0.0 0.0 -0.5 0.5 -0.5 0.5 /$(arg name)_depth_frame /$(arg name)_depth_optical_frame"/>
+
+		<node pkg="tf2_ros" type="static_transform_publisher" name="stp_ir_frame" args="0.0 0.059 0.0 0.0 0.0 0.0 1.0 /$(arg name)_link /$(arg name)_ir_frame"/>
+		<node pkg="tf2_ros" type="static_transform_publisher" name="stp_ir_optical_frame" args="0.0 0.0 0.0 -0.5 0.5 -0.5 0.5 /$(arg name)_ir_frame /$(arg name)_ir_optical_frame"/>
+
+		<node pkg="tf2_ros" type="static_transform_publisher" name="stp_ir2_frame" args="0.0 -0.011 0.0 0.0 0.0 0.0 1.0 /$(arg name)_link /$(arg name)_ir2_frame"/>
+		<node pkg="tf2_ros" type="static_transform_publisher" name="stp_ir2_optical_frame" args="0.0 0.0 0.0 -0.5 0.5 -0.5 0.5 /$(arg name)_ir2_frame /$(arg name)_ir2_optical_frame"/>
+	</group>
 </launch>

--- a/cob_bringup/package.xml
+++ b/cob_bringup/package.xml
@@ -86,6 +86,7 @@
   <exec_depend>schunk_powercube_chain</exec_depend>
   <exec_depend>sick_visionary_t_driver</exec_depend>
   <exec_depend>spacenav_node</exec_depend>
+  <exec_depend>tf2_ros</exec_depend>
   <exec_depend>theora_image_transport</exec_depend> <!-- needed by the cameras to publish the compressed topics -->
   <exec_depend>topic_tools</exec_depend>
   <exec_depend>twist_mux</exec_depend>


### PR DESCRIPTION
fix https://github.com/ipa320/cob_common/issues/212

this adds static tf broadcasters for the realsense frames for simulation.
these frames are broadcasted by the driver when working with the real camera and thus have been missing in simulation so far...

@ipa-bnm @ipa-nhg please test