### PR TITLE
use topic_status_monitor (0.5)

### DIFF
--- a/cob_bringup/tools/hz_monitor.launch
+++ b/cob_bringup/tools/hz_monitor.launch
@@ -6,9 +6,8 @@
 	<arg name="pkg_hardware_config" default="$(find cob_hardware_config)"/>
 
 	<!-- start hz monitor node -->
-	<node name="hz_monitor_$(arg yaml_name)" pkg="cob_monitoring" type="hz_monitor.py" respawn="false" output="screen">
+	<node name="hz_monitor_$(arg yaml_name)" pkg="cob_monitoring" type="topic_status_monitor" respawn="false" output="screen">
 		<rosparam command="load" file="$(arg pkg_hardware_config)/robots/$(arg robot)/config/hz_monitor_$(arg yaml_name).yaml"/>
-		<remap from="~diagnostics" to="/diagnostics"/>
 	</node>
 
 </launch>


### PR DESCRIPTION
proposes to use the diagnostic_updater-based node from https://github.com/ipa320/cob_command_tools/pull/170 as a drop-in replacement for `hz_monitor.py`
no need to change/modify any yaml (hz_monitor.yaml, diagnostics_aggregator.yaml)...all works well...it just provides more information about topic status see https://cloud.githubusercontent.com/assets/508006/22161614/7f14c6c4-df4b-11e6-933f-78afe2c41727.png

@ipa-fmw @ipa-nhg 
