### PR TITLE
[DO_NOT_MERGE] testing industrial_ci feature branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ env:
   global:
     - UPSTREAM_WORKSPACE=file
     - NOT_TEST_INSTALL=true
-    - STRICT_TEST_DEPENDS=true
   matrix:
     - ROS_DISTRO="indigo" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
     - ROS_DISTRO="jade" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
   global:
     - UPSTREAM_WORKSPACE=file
     - NOT_TEST_INSTALL=true
+    - STRICT_TEST_DEPENDS=true
   matrix:
     - ROS_DISTRO="indigo" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
     - ROS_DISTRO="jade" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
   allow_failures:
     - env: ROS_DISTRO="jade" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
 install:
-  - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config
+  - git clone -b enhancement/106 https://github.com/ipa-mdl/industrial_ci.git .ci_config
 script:
   - .ci_config/travis.sh
 #  - ./travis.sh  # Enable this when you have a package-local script


### PR DESCRIPTION
this is just for testing @ipa-mdl feature branch for industrial_ci which is proposed in https://github.com/ros-industrial/industrial_ci/pull/137

this should speed up the build process, because it only builds packages that are direct or transitive dependencies of `cob_robots`
it will also help with the current problem of `cob_robots` CI failing because of missing rosdep key for `stomp_moveit` which is a dependency of `cob_moveit_bringup` which occurs in the workspace because of `cob_manipulation` being in the `.rosinstall` file - but not having `industrial_moveit` in the `.rosinstall` file