### PR TITLE
use cob4_arm description

### DIFF
--- a/cob_hardware_config/package.xml
+++ b/cob_hardware_config/package.xml
@@ -26,7 +26,6 @@
   <exec_depend>joint_trajectory_controller</exec_depend>
   <exec_depend>position_controllers</exec_depend>
   <exec_depend>raw_description</exec_depend>
-  <exec_depend>schunk_description</exec_depend>
   <exec_depend>ur_description</exec_depend>
   <exec_depend>velocity_controllers</exec_depend>
   <exec_depend>xacro</exec_depend>

--- a/cob_hardware_config/robots/cob4-10/urdf/cob4-10.urdf.xacro
+++ b/cob_hardware_config/robots/cob4-10/urdf/cob4-10.urdf.xacro
@@ -5,7 +5,6 @@
   <!-- common stuff -->
   <xacro:include filename="$(find cob_description)/urdf/common.xacro" />
   <xacro:include filename="$(find cob_description)/urdf/materials.urdf.xacro" />
-  <xacro:include filename="$(find schunk_description)/urdf/materials.urdf.xacro" />
 
   <!-- calibration -->
   <xacro:include filename="$(find cob_hardware_config)/robots/cob4-10/urdf/properties.urdf.xacro" />

--- a/cob_hardware_config/robots/cob4-11/urdf/cob4-11.urdf.xacro
+++ b/cob_hardware_config/robots/cob4-11/urdf/cob4-11.urdf.xacro
@@ -5,7 +5,6 @@
   <!-- common stuff -->
   <xacro:include filename="$(find cob_description)/urdf/common.xacro" />
   <xacro:include filename="$(find cob_description)/urdf/materials.urdf.xacro" />
-  <xacro:include filename="$(find schunk_description)/urdf/materials.urdf.xacro" />
 
   <!-- calibration -->
   <xacro:include filename="$(find cob_hardware_config)/robots/cob4-11/urdf/properties.urdf.xacro" />

--- a/cob_hardware_config/robots/cob4-2/urdf/cob4-2.urdf.xacro
+++ b/cob_hardware_config/robots/cob4-2/urdf/cob4-2.urdf.xacro
@@ -5,7 +5,6 @@
   <!-- common stuff -->
   <xacro:include filename="$(find cob_description)/urdf/common.xacro" />
   <xacro:include filename="$(find cob_description)/urdf/materials.urdf.xacro" />
-  <xacro:include filename="$(find schunk_description)/urdf/materials.urdf.xacro" />
 
   <!-- calibration -->
   <xacro:include filename="$(find cob_hardware_config)/robots/cob4-2/urdf/properties.urdf.xacro" />

--- a/cob_hardware_config/robots/cob4-5/urdf/cob4-5.urdf.xacro
+++ b/cob_hardware_config/robots/cob4-5/urdf/cob4-5.urdf.xacro
@@ -5,7 +5,6 @@
   <!-- common stuff -->
   <xacro:include filename="$(find cob_description)/urdf/common.xacro" />
   <xacro:include filename="$(find cob_description)/urdf/materials.urdf.xacro" />
-  <xacro:include filename="$(find schunk_description)/urdf/materials.urdf.xacro" />
 
   <!-- calibration -->
   <xacro:include filename="$(find cob_hardware_config)/robots/cob4-5/urdf/properties.urdf.xacro" />
@@ -17,7 +16,7 @@
   <xacro:include filename="$(find cob_description)/urdf/cob4_torso/torso.urdf.xacro" />
 
   <!-- arm -->
-  <xacro:include filename="$(find schunk_description)/urdf/lwa4p_extended/lwa4p_extended.urdf.xacro" />
+  <xacro:include filename="$(find cob_description)/urdf/cob4_arm/cob4_arm.urdf.xacro" />
 
   <!-- hand -->
   <xacro:include filename="$(find cob_description)/urdf/cob4_gripper/gripper.urdf.xacro" />
@@ -84,13 +83,13 @@
     <origin xyz="${sensorring_cam3d_back_x} ${sensorring_cam3d_back_y} ${sensorring_cam3d_back_z}" rpy="${sensorring_cam3d_back_roll} ${sensorring_cam3d_back_pitch} ${sensorring_cam3d_back_yaw}" />
   </xacro:cob_kinect_v0>
 
-  <xacro:schunk_lwa4p_extended name="arm_right" parent="torso_3_link" has_podest="false">
+  <xacro:cob4_arm name="arm_right" parent="torso_3_link" has_podest="false">
     <origin xyz="${arm_right_x} ${arm_right_y} ${arm_right_z}" rpy="${arm_right_roll} ${arm_right_pitch} ${arm_right_yaw}" />
-  </xacro:schunk_lwa4p_extended>
+  </xacro:cob4_arm>
 
-  <xacro:schunk_lwa4p_extended name="arm_left" parent="torso_3_link" has_podest="false">
+  <xacro:cob4_arm name="arm_left" parent="torso_3_link" has_podest="false">
     <origin xyz="${arm_left_x} ${arm_left_y} ${arm_left_z}" rpy="${arm_left_roll} ${arm_left_pitch} ${arm_left_yaw}" />
-  </xacro:schunk_lwa4p_extended>
+  </xacro:cob4_arm>
 
   <xacro:gripper name="gripper_right" parent="arm_right_7_link">
     <origin xyz="${gripper_right_x} ${gripper_right_y} ${gripper_right_z}" rpy="${gripper_right_roll} ${gripper_right_pitch} ${gripper_right_yaw}" />

--- a/cob_hardware_config/robots/cob4-7/urdf/cob4-7.urdf.xacro
+++ b/cob_hardware_config/robots/cob4-7/urdf/cob4-7.urdf.xacro
@@ -5,7 +5,6 @@
   <!-- common stuff -->
   <xacro:include filename="$(find cob_description)/urdf/common.xacro" />
   <xacro:include filename="$(find cob_description)/urdf/materials.urdf.xacro" />
-  <xacro:include filename="$(find schunk_description)/urdf/materials.urdf.xacro" />
 
   <!-- calibration -->
   <xacro:include filename="$(find cob_hardware_config)/robots/cob4-7/urdf/properties.urdf.xacro" />

--- a/cob_hardware_config/robots/cob4-8/urdf/cob4-8.urdf.xacro
+++ b/cob_hardware_config/robots/cob4-8/urdf/cob4-8.urdf.xacro
@@ -5,7 +5,6 @@
   <!-- common stuff -->
   <xacro:include filename="$(find cob_description)/urdf/common.xacro" />
   <xacro:include filename="$(find cob_description)/urdf/materials.urdf.xacro" />
-  <xacro:include filename="$(find schunk_description)/urdf/materials.urdf.xacro" />
 
   <!-- calibration -->
   <xacro:include filename="$(find cob_hardware_config)/robots/cob4-8/urdf/properties.urdf.xacro" />
@@ -17,7 +16,7 @@
   <xacro:include filename="$(find cob_description)/urdf/cob4_torso/torso.urdf.xacro" />
 
   <!-- arm -->
-  <xacro:include filename="$(find schunk_description)/urdf/lwa4p_extended/lwa4p_extended.urdf.xacro" />
+  <xacro:include filename="$(find cob_description)/urdf/cob4_arm/cob4_arm.urdf.xacro" />
 
   <!-- hand -->
   <xacro:include filename="$(find cob_description)/urdf/cob4_gripper/gripper.urdf.xacro" />
@@ -81,13 +80,13 @@
     <origin xyz="${sensorring_cam3d_x} ${sensorring_cam3d_y} ${sensorring_cam3d_z}" rpy="${sensorring_cam3d_roll} ${sensorring_cam3d_pitch} ${sensorring_cam3d_yaw}" />
   </xacro:cob_kinect_v0>
 
-  <xacro:schunk_lwa4p_extended name="arm_right" parent="torso_3_link" has_podest="false">
+  <xacro:cob4_arm name="arm_right" parent="torso_3_link" has_podest="false">
     <origin xyz="${arm_right_x} ${arm_right_y} ${arm_right_z}" rpy="${arm_right_roll} ${arm_right_pitch} ${arm_right_yaw}" />
-  </xacro:schunk_lwa4p_extended>
+  </xacro:cob4_arm>
 
-  <xacro:schunk_lwa4p_extended name="arm_left" parent="torso_3_link" has_podest="false">
+  <xacro:cob4_arm name="arm_left" parent="torso_3_link" has_podest="false">
     <origin xyz="${arm_left_x} ${arm_left_y} ${arm_left_z}" rpy="${arm_left_roll} ${arm_left_pitch} ${arm_left_yaw}" />
-  </xacro:schunk_lwa4p_extended>
+  </xacro:cob4_arm>
 
   <xacro:gripper name="gripper_right" parent="arm_right_7_link">
     <origin xyz="${gripper_right_x} ${gripper_right_y} ${gripper_right_z}" rpy="${gripper_right_roll} ${gripper_right_pitch} ${gripper_right_yaw}" />

--- a/cob_hardware_config/robots/cob4-9/urdf/cob4-9.urdf.xacro
+++ b/cob_hardware_config/robots/cob4-9/urdf/cob4-9.urdf.xacro
@@ -5,7 +5,6 @@
   <!-- common stuff -->
   <xacro:include filename="$(find cob_description)/urdf/common.xacro" />
   <xacro:include filename="$(find cob_description)/urdf/materials.urdf.xacro" />
-  <xacro:include filename="$(find schunk_description)/urdf/materials.urdf.xacro" />
 
   <!-- calibration -->
   <xacro:include filename="$(find cob_hardware_config)/robots/cob4-9/urdf/properties.urdf.xacro" />


### PR DESCRIPTION
requires https://github.com/ipa320/cob_common/pull/227

this PR removes the dependency of `cob_robots` to `schunk_description` by copying `schunk_lwa4p_extended` to `cob_description` (see https://github.com/ipa320/cob_common/pull/227) + some cleanup