### PR TITLE
remove cob_trajectory_controller

### DIFF
--- a/cob_bringup/package.xml
+++ b/cob_bringup/package.xml
@@ -57,7 +57,6 @@
   <exec_depend>cob_sick_s300</exec_depend>
   <exec_depend>cob_sound</exec_depend>
   <exec_depend>cob_teleop</exec_depend>
-  <exec_depend>cob_trajectory_controller</exec_depend>
   <exec_depend>cob_twist_controller</exec_depend>
   <exec_depend>cob_undercarriage_ctrl</exec_depend>
   <exec_depend>cob_voltage_control</exec_depend>


### PR DESCRIPTION
 - fixes parts of https://github.com/ipa320/care-o-bot/issues/46
- requires https://github.com/ipa320/cob_control/pull/161