### PR TITLE
add ntp monitor

### DIFF
--- a/cob_bringup/robots/cob4-10.xml
+++ b/cob_bringup/robots/cob4-10.xml
@@ -119,6 +119,7 @@
 			<include file="$(find cob_bringup)/tools/pc_monitor.launch">
 				<arg name="robot" value="$(arg robot)"/>
 				<arg name="pc" value="$(arg cob4-10-t1)"/>
+				<arg name="ntp_server" value="$(arg cob4-10-b1)"/>
 			</include>
 		</group>
 
@@ -180,6 +181,7 @@
 			<include file="$(find cob_bringup)/tools/pc_monitor.launch">
 				<arg name="robot" value="$(arg robot)"/>
 				<arg name="pc" value="$(arg cob4-10-t2)"/>
+				<arg name="ntp_server" value="$(arg cob4-10-b1)"/>
 			</include>
 		</group>
 
@@ -200,6 +202,7 @@
 			<include file="$(find cob_bringup)/tools/pc_monitor.launch">
 				<arg name="robot" value="$(arg robot)"/>
 				<arg name="pc" value="$(arg cob4-10-t3)"/>
+				<arg name="ntp_server" value="$(arg cob4-10-b1)"/>
 			</include>
 		</group>
 
@@ -228,6 +231,7 @@
 			<include file="$(find cob_bringup)/tools/pc_monitor.launch">
 				<arg name="robot" value="$(arg robot)"/>
 				<arg name="pc" value="$(arg cob4-10-s1)"/>
+				<arg name="ntp_server" value="$(arg cob4-10-b1)"/>
 			</include>
 		</group>
 
@@ -256,6 +260,7 @@
 			<include file="$(find cob_bringup)/tools/pc_monitor.launch">
 				<arg name="robot" value="$(arg robot)"/>
 				<arg name="pc" value="$(arg cob4-10-h1)"/>
+				<arg name="ntp_server" value="$(arg cob4-10-b1)"/>
 			</include>
 		</group>
 

--- a/cob_bringup/robots/cob4-10.xml
+++ b/cob_bringup/robots/cob4-10.xml
@@ -35,6 +35,7 @@
 			<include file="$(find cob_bringup)/tools/pc_monitor.launch">
 				<arg name="robot" value="$(arg robot)"/>
 				<arg name="pc" value="$(arg cob4-10-b1)"/>
+				<arg name="ntp_server" value="de.pool.ntp.org"/>
 			</include>
 		</group>
 

--- a/cob_bringup/robots/cob4-11.xml
+++ b/cob_bringup/robots/cob4-11.xml
@@ -24,6 +24,7 @@
 			<include file="$(find cob_bringup)/tools/pc_monitor.launch">
 				<arg name="robot" value="$(arg robot)"/>
 				<arg name="pc" value="$(arg cob4-11-b1)"/>
+				<arg name="ntp_server" value="de.pool.ntp.org"/>
 			</include>
 		</group>
 

--- a/cob_bringup/robots/cob4-2.xml
+++ b/cob_bringup/robots/cob4-2.xml
@@ -35,6 +35,7 @@
 			<include file="$(find cob_bringup)/tools/pc_monitor.launch">
 				<arg name="robot" value="$(arg robot)"/>
 				<arg name="pc" value="$(arg cob4-2-b1)"/>
+				<arg name="ntp_server" value="de.pool.ntp.org"/>
 			</include>
 		</group>
 
@@ -118,6 +119,7 @@
 			<include file="$(find cob_bringup)/tools/pc_monitor.launch">
 				<arg name="robot" value="$(arg robot)"/>
 				<arg name="pc" value="$(arg cob4-2-t1)"/>
+				<arg name="ntp_server" value="$(arg cob4-2-b1)"/>
 			</include>
 		</group>
 
@@ -160,6 +162,7 @@
 			<include file="$(find cob_bringup)/tools/pc_monitor.launch">
 				<arg name="robot" value="$(arg robot)"/>
 				<arg name="pc" value="$(arg cob4-2-t2)"/>
+				<arg name="ntp_server" value="$(arg cob4-2-b1)"/>
 			</include>
 		</group>
 
@@ -180,6 +183,7 @@
 			<include file="$(find cob_bringup)/tools/pc_monitor.launch">
 				<arg name="robot" value="$(arg robot)"/>
 				<arg name="pc" value="$(arg cob4-2-t3)"/>
+				<arg name="ntp_server" value="$(arg cob4-2-b1)"/>
 			</include>
 		</group>
 
@@ -202,6 +206,7 @@
 			<include file="$(find cob_bringup)/tools/pc_monitor.launch">
 				<arg name="robot" value="$(arg robot)"/>
 				<arg name="pc" value="$(arg cob4-2-s1)"/>
+				<arg name="ntp_server" value="$(arg cob4-2-b1)"/>
 			</include>
 		</group>
 
@@ -222,6 +227,7 @@
 			<include file="$(find cob_bringup)/tools/pc_monitor.launch">
 				<arg name="robot" value="$(arg robot)"/>
 				<arg name="pc" value="$(arg cob4-2-h1)"/>
+				<arg name="ntp_server" value="$(arg cob4-2-b1)"/>
 			</include>
 		</group>
 

--- a/cob_bringup/robots/cob4-3.xml
+++ b/cob_bringup/robots/cob4-3.xml
@@ -23,6 +23,7 @@
 			<include file="$(find cob_bringup)/tools/pc_monitor.launch">
 				<arg name="robot" value="$(arg robot)"/>
 				<arg name="pc" value="$(arg cob4-3-b1)"/>
+				<arg name="ntp_server" value="de.pool.ntp.org"/>
 			</include>
 		</group>
 

--- a/cob_bringup/robots/cob4-4.xml
+++ b/cob_bringup/robots/cob4-4.xml
@@ -24,6 +24,7 @@
 			<include file="$(find cob_bringup)/tools/pc_monitor.launch">
 				<arg name="robot" value="$(arg robot)"/>
 				<arg name="pc" value="$(arg cob4-4-b1)"/>
+				<arg name="ntp_server" value="de.pool.ntp.org"/>
 			</include>
 		</group>
 

--- a/cob_bringup/robots/cob4-5.xml
+++ b/cob_bringup/robots/cob4-5.xml
@@ -35,6 +35,7 @@
 			<include file="$(find cob_bringup)/tools/pc_monitor.launch">
 				<arg name="robot" value="$(arg robot)"/>
 				<arg name="pc" value="$(arg cob4-5-b1)"/>
+				<arg name="ntp_server" value="de.pool.ntp.org"/>
 			</include>
 		</group>
 
@@ -118,6 +119,7 @@
 			<include file="$(find cob_bringup)/tools/pc_monitor.launch">
 				<arg name="robot" value="$(arg robot)"/>
 				<arg name="pc" value="$(arg cob4-5-t1)"/>
+				<arg name="ntp_server" value="$(arg cob4-5-b1)"/>
 			</include>
 		</group>
 
@@ -186,6 +188,7 @@
 			<include file="$(find cob_bringup)/tools/pc_monitor.launch">
 				<arg name="robot" value="$(arg robot)"/>
 				<arg name="pc" value="$(arg cob4-5-t2)"/>
+				<arg name="ntp_server" value="$(arg cob4-5-b1)"/>
 			</include>
 		</group>
 
@@ -206,6 +209,7 @@
 			<include file="$(find cob_bringup)/tools/pc_monitor.launch">
 				<arg name="robot" value="$(arg robot)"/>
 				<arg name="pc" value="$(arg cob4-5-t3)"/>
+				<arg name="ntp_server" value="$(arg cob4-5-b1)"/>
 			</include>
 		</group>
 
@@ -234,6 +238,7 @@
 			<include file="$(find cob_bringup)/tools/pc_monitor.launch">
 				<arg name="robot" value="$(arg robot)"/>
 				<arg name="pc" value="$(arg cob4-5-s1)"/>
+				<arg name="ntp_server" value="$(arg cob4-5-b1)"/>
 			</include>
 		</group>
 
@@ -261,6 +266,7 @@
 			<include file="$(find cob_bringup)/tools/pc_monitor.launch">
 				<arg name="robot" value="$(arg robot)"/>
 				<arg name="pc" value="$(arg cob4-5-h1)"/>
+				<arg name="ntp_server" value="$(arg cob4-5-b1)"/>
 			</include>
 		</group>
 

--- a/cob_bringup/robots/cob4-6.xml
+++ b/cob_bringup/robots/cob4-6.xml
@@ -24,6 +24,7 @@
 			<include file="$(find cob_bringup)/tools/pc_monitor.launch">
 				<arg name="robot" value="$(arg robot)"/>
 				<arg name="pc" value="$(arg cob4-6-b1)"/>
+				<arg name="ntp_server" value="de.pool.ntp.org"/>
 			</include>
 		</group>
 

--- a/cob_bringup/robots/cob4-7.xml
+++ b/cob_bringup/robots/cob4-7.xml
@@ -35,6 +35,7 @@
 			<include file="$(find cob_bringup)/tools/pc_monitor.launch">
 				<arg name="robot" value="$(arg robot)"/>
 				<arg name="pc" value="$(arg cob4-7-b1)"/>
+				<arg name="ntp_server" value="de.pool.ntp.org"/>
 			</include>
 		</group>
 
@@ -118,6 +119,7 @@
 			<include file="$(find cob_bringup)/tools/pc_monitor.launch">
 				<arg name="robot" value="$(arg robot)"/>
 				<arg name="pc" value="$(arg cob4-7-t1)"/>
+				<arg name="ntp_server" value="$(arg cob4-7-b1)"/>
 			</include>
 		</group>
 
@@ -179,6 +181,7 @@
 			<include file="$(find cob_bringup)/tools/pc_monitor.launch">
 				<arg name="robot" value="$(arg robot)"/>
 				<arg name="pc" value="$(arg cob4-7-t2)"/>
+				<arg name="ntp_server" value="$(arg cob4-7-b1)"/>
 			</include>
 		</group>
 
@@ -199,6 +202,7 @@
 			<include file="$(find cob_bringup)/tools/pc_monitor.launch">
 				<arg name="robot" value="$(arg robot)"/>
 				<arg name="pc" value="$(arg cob4-7-t3)"/>
+				<arg name="ntp_server" value="$(arg cob4-7-b1)"/>
 			</include>
 		</group>
 
@@ -221,6 +225,7 @@
 			<include file="$(find cob_bringup)/tools/pc_monitor.launch">
 				<arg name="robot" value="$(arg robot)"/>
 				<arg name="pc" value="$(arg cob4-7-s1)"/>
+				<arg name="ntp_server" value="$(arg cob4-7-b1)"/>
 			</include>
 		</group>
 
@@ -241,6 +246,7 @@
 			<include file="$(find cob_bringup)/tools/pc_monitor.launch">
 				<arg name="robot" value="$(arg robot)"/>
 				<arg name="pc" value="$(arg cob4-7-h1)"/>
+				<arg name="ntp_server" value="$(arg cob4-7-b1)"/>
 			</include>
 		</group>
 

--- a/cob_bringup/robots/cob4-8.xml
+++ b/cob_bringup/robots/cob4-8.xml
@@ -35,6 +35,7 @@
 			<include file="$(find cob_bringup)/tools/pc_monitor.launch">
 				<arg name="robot" value="$(arg robot)"/>
 				<arg name="pc" value="$(arg cob4-8-b1)"/>
+				<arg name="ntp_server" value="de.pool.ntp.org"/>
 			</include>
 		</group>
 
@@ -118,6 +119,7 @@
 			<include file="$(find cob_bringup)/tools/pc_monitor.launch">
 				<arg name="robot" value="$(arg robot)"/>
 				<arg name="pc" value="$(arg cob4-8-t1)"/>
+				<arg name="ntp_server" value="$(arg cob4-8-b1)"/>
 			</include>
 		</group>
 
@@ -186,6 +188,7 @@
 			<include file="$(find cob_bringup)/tools/pc_monitor.launch">
 				<arg name="robot" value="$(arg robot)"/>
 				<arg name="pc" value="$(arg cob4-8-t2)"/>
+				<arg name="ntp_server" value="$(arg cob4-8-b1)"/>
 			</include>
 		</group>
 
@@ -206,6 +209,7 @@
 			<include file="$(find cob_bringup)/tools/pc_monitor.launch">
 				<arg name="robot" value="$(arg robot)"/>
 				<arg name="pc" value="$(arg cob4-8-t3)"/>
+				<arg name="ntp_server" value="$(arg cob4-8-b1)"/>
 			</include>
 		</group>
 
@@ -234,6 +238,7 @@
 			<include file="$(find cob_bringup)/tools/pc_monitor.launch">
 				<arg name="robot" value="$(arg robot)"/>
 				<arg name="pc" value="$(arg cob4-8-s1)"/>
+				<arg name="ntp_server" value="$(arg cob4-8-b1)"/>
 			</include>
 		</group>
 
@@ -255,6 +260,7 @@
 			<include file="$(find cob_bringup)/tools/pc_monitor.launch">
 				<arg name="robot" value="$(arg robot)"/>
 				<arg name="pc" value="$(arg cob4-8-h1)"/>
+				<arg name="ntp_server" value="$(arg cob4-8-b1)"/>
 			</include>
 		</group>
 

--- a/cob_bringup/robots/cob4-9.xml
+++ b/cob_bringup/robots/cob4-9.xml
@@ -24,6 +24,7 @@
 			<include file="$(find cob_bringup)/tools/pc_monitor.launch">
 				<arg name="robot" value="$(arg robot)"/>
 				<arg name="pc" value="$(arg cob4-9-b1)"/>
+				<arg name="ntp_server" value="de.pool.ntp.org"/>
 			</include>
 		</group>
 

--- a/cob_bringup/robots/raw3-1.xml
+++ b/cob_bringup/robots/raw3-1.xml
@@ -26,6 +26,7 @@
 			<include file="$(find cob_bringup)/tools/pc_monitor.launch">
 				<arg name="robot" value="$(arg robot)"/>
 				<arg name="pc" value="$(arg pc1)"/>
+				<arg name="ntp_server" value="de.pool.ntp.org"/>
 			</include>
 			<!--include file="$(find cob_bringup)/tools/wifi_monitor.launch">
 				<arg name="robot" value="$(arg robot)"/>
@@ -103,6 +104,7 @@
 			<include file="$(find cob_bringup)/tools/pc_monitor.launch">
 				<arg name="robot" value="$(arg robot)"/>
 				<arg name="pc" value="$(arg pc2)"/>
+				<arg name="ntp_server" value="$(arg pc1)"/>
 			</include>
 		</group>
 

--- a/cob_bringup/robots/raw3-3.xml
+++ b/cob_bringup/robots/raw3-3.xml
@@ -26,6 +26,7 @@
 			<include file="$(find cob_bringup)/tools/pc_monitor.launch">
 				<arg name="robot" value="$(arg robot)"/>
 				<arg name="pc" value="$(arg pc1)"/>
+				<arg name="ntp_server" value="de.pool.ntp.org"/>
 			</include>
 			<include file="$(find cob_bringup)/drivers/phidgets.launch">
 				<arg name="robot" value="$(arg robot)"/>
@@ -86,7 +87,7 @@
 		
 		<!-- simulation only -->
 		<include if="$(arg sim)" file="$(find cob_bringup)/tools/fake_diagnostics.launch">
-			<arg name="fake_diagnostics" value="'base_laser_front, base_laser_rear, -pc1, -pc2, -pc3, joy'"/>
+			<arg name="fake_diagnostics" value="'base_laser_front, base_laser_rear, -pc1, -pc2, joy'"/>
 		</include>
 	</group>
 

--- a/cob_bringup/robots/raw3-5.xml
+++ b/cob_bringup/robots/raw3-5.xml
@@ -24,6 +24,7 @@
 			<include file="$(find cob_bringup)/tools/pc_monitor.launch">
 				<arg name="robot" value="$(arg robot)"/>
 				<arg name="pc" value="$(arg pc1)"/>
+				<arg name="ntp_server" value="de.pool.ntp.org"/>
 			</include>
 			<include file="$(find cob_bringup)/drivers/phidgets.launch">
 				<arg name="robot" value="$(arg robot)"/>

--- a/cob_bringup/tools/pc_monitor.launch
+++ b/cob_bringup/tools/pc_monitor.launch
@@ -5,6 +5,7 @@
 	<arg name="pkg_hardware_config" default="$(find cob_hardware_config)"/>
 	<arg name="pc" default="localhost"/>
 	<arg name="diag_hostname" default="$(arg pc)"/>
+        <arg name="ntp_server" default="localhost"/>
 
 	<!-- Monitor CPU (temp, usage) -->
 	<node pkg="cob_monitoring" name="$(anon cpu_monitor)" type="cpu_monitor.py" args="--diag-hostname=$(arg diag_hostname)" output="screen">
@@ -15,9 +16,9 @@
 	<node pkg="cob_monitoring" name="$(anon hd_monitor)" type="hd_monitor.py" args="--diag-hostname=$(arg diag_hostname)" output="screen"/>
 
 	<!-- Monitor ntp -->
-	<!--node pkg="cob_monitoring" name="$(anon realtime_ntp_monitor)" type="ntp_monitor.py" args="$(arg pc) -/-diag-hostname=$(arg pc)" output="screen">
-		<rosparam command="load" file="$(arg pkg_hardware_config)/robots/$(arg robot)/config/pc_monitor_$(arg pc).yaml"/>
-	</node-->
+	<node pkg="cob_monitoring" name="$(anon ntp_monitor)" type="ntp_monitor.py" args="$(arg ntp_server) --diag-hostname=$(arg diag_hostname)" output="screen">
+		<rosparam command="load" file="$(arg pkg_hardware_config)/robots/$(arg robot)/config/ntp_monitor.yaml"/>
+	</node>
 
 
 </launch>

--- a/cob_bringup/tools/pc_monitor.launch
+++ b/cob_bringup/tools/pc_monitor.launch
@@ -5,7 +5,7 @@
 	<arg name="pkg_hardware_config" default="$(find cob_hardware_config)"/>
 	<arg name="pc" default="localhost"/>
 	<arg name="diag_hostname" default="$(arg pc)"/>
-        <arg name="ntp_server" default="localhost"/>
+	<arg name="ntp_server" default="localhost"/>
 
 	<!-- Monitor CPU (temp, usage) -->
 	<node pkg="cob_monitoring" name="$(anon cpu_monitor)" type="cpu_monitor.py" args="--diag-hostname=$(arg diag_hostname)" output="screen">

--- a/cob_hardware_config/robots/cob4-10/config/ntp_monitor.yaml
+++ b/cob_hardware_config/robots/cob4-10/config/ntp_monitor.yaml
@@ -1,0 +1,2 @@
+offset: 500            #us
+error_offset: 5000000  #us

--- a/cob_hardware_config/robots/cob4-10/config/ntp_monitor.yaml
+++ b/cob_hardware_config/robots/cob4-10/config/ntp_monitor.yaml
@@ -1,2 +1,2 @@
-offset: 500            #us
-error_offset: 5000000  #us
+offset: 500          #us
+error_offset: 25000  #us

--- a/cob_hardware_config/robots/cob4-11/config/ntp_monitor.yaml
+++ b/cob_hardware_config/robots/cob4-11/config/ntp_monitor.yaml
@@ -1,0 +1,2 @@
+offset: 500            #us
+error_offset: 5000000  #us

--- a/cob_hardware_config/robots/cob4-11/config/ntp_monitor.yaml
+++ b/cob_hardware_config/robots/cob4-11/config/ntp_monitor.yaml
@@ -1,2 +1,2 @@
-offset: 500            #us
-error_offset: 5000000  #us
+offset: 500          #us
+error_offset: 25000  #us

--- a/cob_hardware_config/robots/cob4-2/config/ntp_monitor.yaml
+++ b/cob_hardware_config/robots/cob4-2/config/ntp_monitor.yaml
@@ -1,0 +1,2 @@
+offset: 500            #us
+error_offset: 5000000  #us

--- a/cob_hardware_config/robots/cob4-2/config/ntp_monitor.yaml
+++ b/cob_hardware_config/robots/cob4-2/config/ntp_monitor.yaml
@@ -1,2 +1,2 @@
-offset: 500            #us
-error_offset: 5000000  #us
+offset: 500          #us
+error_offset: 25000  #us

--- a/cob_hardware_config/robots/cob4-3/config/ntp_monitor.yaml
+++ b/cob_hardware_config/robots/cob4-3/config/ntp_monitor.yaml
@@ -1,0 +1,2 @@
+offset: 500            #us
+error_offset: 5000000  #us

--- a/cob_hardware_config/robots/cob4-3/config/ntp_monitor.yaml
+++ b/cob_hardware_config/robots/cob4-3/config/ntp_monitor.yaml
@@ -1,2 +1,2 @@
-offset: 500            #us
-error_offset: 5000000  #us
+offset: 500          #us
+error_offset: 25000  #us

--- a/cob_hardware_config/robots/cob4-4/config/ntp_monitor.yaml
+++ b/cob_hardware_config/robots/cob4-4/config/ntp_monitor.yaml
@@ -1,0 +1,2 @@
+offset: 500            #us
+error_offset: 5000000  #us

--- a/cob_hardware_config/robots/cob4-4/config/ntp_monitor.yaml
+++ b/cob_hardware_config/robots/cob4-4/config/ntp_monitor.yaml
@@ -1,2 +1,2 @@
-offset: 500            #us
-error_offset: 5000000  #us
+offset: 500          #us
+error_offset: 25000  #us

--- a/cob_hardware_config/robots/cob4-5/config/ntp_monitor.yaml
+++ b/cob_hardware_config/robots/cob4-5/config/ntp_monitor.yaml
@@ -1,0 +1,2 @@
+offset: 500            #us
+error_offset: 5000000  #us

--- a/cob_hardware_config/robots/cob4-5/config/ntp_monitor.yaml
+++ b/cob_hardware_config/robots/cob4-5/config/ntp_monitor.yaml
@@ -1,2 +1,2 @@
-offset: 500            #us
-error_offset: 5000000  #us
+offset: 500          #us
+error_offset: 25000  #us

--- a/cob_hardware_config/robots/cob4-6/config/ntp_monitor.yaml
+++ b/cob_hardware_config/robots/cob4-6/config/ntp_monitor.yaml
@@ -1,0 +1,2 @@
+offset: 500            #us
+error_offset: 5000000  #us

--- a/cob_hardware_config/robots/cob4-6/config/ntp_monitor.yaml
+++ b/cob_hardware_config/robots/cob4-6/config/ntp_monitor.yaml
@@ -1,2 +1,2 @@
-offset: 500            #us
-error_offset: 5000000  #us
+offset: 500          #us
+error_offset: 25000  #us

--- a/cob_hardware_config/robots/cob4-7/config/ntp_monitor.yaml
+++ b/cob_hardware_config/robots/cob4-7/config/ntp_monitor.yaml
@@ -1,0 +1,2 @@
+offset: 500            #us
+error_offset: 5000000  #us

--- a/cob_hardware_config/robots/cob4-7/config/ntp_monitor.yaml
+++ b/cob_hardware_config/robots/cob4-7/config/ntp_monitor.yaml
@@ -1,2 +1,2 @@
-offset: 500            #us
-error_offset: 5000000  #us
+offset: 500          #us
+error_offset: 25000  #us

--- a/cob_hardware_config/robots/cob4-8/config/ntp_monitor.yaml
+++ b/cob_hardware_config/robots/cob4-8/config/ntp_monitor.yaml
@@ -1,0 +1,2 @@
+offset: 500            #us
+error_offset: 5000000  #us

--- a/cob_hardware_config/robots/cob4-8/config/ntp_monitor.yaml
+++ b/cob_hardware_config/robots/cob4-8/config/ntp_monitor.yaml
@@ -1,2 +1,2 @@
-offset: 500            #us
-error_offset: 5000000  #us
+offset: 500          #us
+error_offset: 25000  #us

--- a/cob_hardware_config/robots/cob4-9/config/ntp_monitor.yaml
+++ b/cob_hardware_config/robots/cob4-9/config/ntp_monitor.yaml
@@ -1,0 +1,2 @@
+offset: 500            #us
+error_offset: 5000000  #us

--- a/cob_hardware_config/robots/cob4-9/config/ntp_monitor.yaml
+++ b/cob_hardware_config/robots/cob4-9/config/ntp_monitor.yaml
@@ -1,2 +1,2 @@
-offset: 500            #us
-error_offset: 5000000  #us
+offset: 500          #us
+error_offset: 25000  #us

--- a/cob_hardware_config/robots/raw3-1/config/ntp_monitor.yaml
+++ b/cob_hardware_config/robots/raw3-1/config/ntp_monitor.yaml
@@ -1,0 +1,2 @@
+offset: 500            #us
+error_offset: 5000000  #us

--- a/cob_hardware_config/robots/raw3-1/config/ntp_monitor.yaml
+++ b/cob_hardware_config/robots/raw3-1/config/ntp_monitor.yaml
@@ -1,2 +1,2 @@
-offset: 500            #us
-error_offset: 5000000  #us
+offset: 500          #us
+error_offset: 25000  #us

--- a/cob_hardware_config/robots/raw3-3/config/ntp_monitor.yaml
+++ b/cob_hardware_config/robots/raw3-3/config/ntp_monitor.yaml
@@ -1,0 +1,2 @@
+offset: 500            #us
+error_offset: 5000000  #us

--- a/cob_hardware_config/robots/raw3-3/config/ntp_monitor.yaml
+++ b/cob_hardware_config/robots/raw3-3/config/ntp_monitor.yaml
@@ -1,2 +1,2 @@
-offset: 500            #us
-error_offset: 5000000  #us
+offset: 500          #us
+error_offset: 25000  #us

--- a/cob_hardware_config/robots/raw3-5/config/ntp_monitor.yaml
+++ b/cob_hardware_config/robots/raw3-5/config/ntp_monitor.yaml
@@ -1,0 +1,2 @@
+offset: 500            #us
+error_offset: 5000000  #us

--- a/cob_hardware_config/robots/raw3-5/config/ntp_monitor.yaml
+++ b/cob_hardware_config/robots/raw3-5/config/ntp_monitor.yaml
@@ -1,2 +1,2 @@
-offset: 500            #us
-error_offset: 5000000  #us
+offset: 500          #us
+error_offset: 25000  #us


### PR DESCRIPTION
fixes https://github.com/ipa320/msh/issues/802
requires https://github.com/ipa320/cob_command_tools/pull/200

this activates the ntp_monitor note to detect time sync drifts between the robot pcs...

related to https://github.com/ipa320/msh/issues/802

I need to test this on a robot in order to set thresholds offsets and thresholds accordingly
Also, the `diagnostics_analyzer.yaml` need to be updated properly

 - [x] add to all robots
 - [x] ntpserver for base?
 - [x] configure diagnostic_analyzer (?)