### PR TITLE
fix mimic vs sound issue

### DIFF
--- a/cob_bringup/CMakeLists.txt
+++ b/cob_bringup/CMakeLists.txt
@@ -20,7 +20,9 @@ install(DIRECTORY components controllers drivers robots tools
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
 
-install(PROGRAMS env.sh
+install(PROGRAMS 
+  env.sh
+  env.sh.display
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
 

--- a/cob_bringup/env.sh.display
+++ b/cob_bringup/env.sh.display
@@ -14,5 +14,6 @@ else
 fi
 
 export ROS_IP=`hostname -I | awk '{print $1}'`
+export DISPLAY=:0
 
 exec "$@"

--- a/cob_bringup/robots/cob4-2.xml
+++ b/cob_bringup/robots/cob4-2.xml
@@ -236,7 +236,7 @@
 		</include>
 	</group>
 
-	<group> <!-- this is a special ground to assign DISPLAY:=0 only to the mimic node (and not to all other nodes, e.g. sound node) -->
+	<group> <!-- this is a special group to assign DISPLAY:=0 only to the mimic node (and not to all other nodes, e.g. sound node) -->
 		<machine name="cob4-2-h1-display" address="$(arg cob4-2-h1)" env-loader="$(arg env-script).display" default="true" timeout="30"/>
 		<include file="$(find cob_bringup)/drivers/mimic.launch"/>
 	</group>

--- a/cob_bringup/robots/cob4-2.xml
+++ b/cob_bringup/robots/cob4-2.xml
@@ -225,7 +225,6 @@
 			</include>
 		</group>
 
-		<include file="$(find cob_bringup)/drivers/mimic.launch"/>
 		<include file="$(find cob_bringup)/components/cob4_head_camera.launch">
 			<arg name="robot" value="$(arg robot)"/>
 			<arg name="sim" value="$(arg sim)"/>
@@ -235,6 +234,11 @@
 		<include file="$(find cob_bringup)/drivers/sound.launch">
 			<arg name="robot" value="$(arg robot)"/>
 		</include>
+	</group>
+
+	<group> <!-- this is a special ground to assign DISPLAY:=0 only to the mimic node (and not to all other nodes, e.g. sound node) -->
+		<machine name="cob4-7-h1-display" address="$(arg cob4-7-h1)" env-loader="$(arg env-script).display" default="true" timeout="30"/>
+		<include file="$(find cob_bringup)/drivers/mimic.launch"/>
 	</group>
 
 	<machine name="cob4-2-b1" address="$(arg cob4-2-b1)" env-loader="$(arg env-script)" default="true" timeout="30"/>

--- a/cob_bringup/robots/cob4-2.xml
+++ b/cob_bringup/robots/cob4-2.xml
@@ -237,7 +237,7 @@
 	</group>
 
 	<group> <!-- this is a special ground to assign DISPLAY:=0 only to the mimic node (and not to all other nodes, e.g. sound node) -->
-		<machine name="cob4-7-h1-display" address="$(arg cob4-7-h1)" env-loader="$(arg env-script).display" default="true" timeout="30"/>
+		<machine name="cob4-2-h1-display" address="$(arg cob4-2-h1)" env-loader="$(arg env-script).display" default="true" timeout="30"/>
 		<include file="$(find cob_bringup)/drivers/mimic.launch"/>
 	</group>
 

--- a/cob_bringup/robots/cob4-5.xml
+++ b/cob_bringup/robots/cob4-5.xml
@@ -275,7 +275,7 @@
 		</include>
 	</group>
 
-	<group> <!-- this is a special ground to assign DISPLAY:=0 only to the mimic node (and not to all other nodes, e.g. sound node) -->
+	<group> <!-- this is a special group to assign DISPLAY:=0 only to the mimic node (and not to all other nodes, e.g. sound node) -->
 		<machine name="cob4-5-h1-display" address="$(arg cob4-5-h1)" env-loader="$(arg env-script).display" default="true" timeout="30"/>
 		<include file="$(find cob_bringup)/drivers/mimic.launch"/>
 	</group>

--- a/cob_bringup/robots/cob4-5.xml
+++ b/cob_bringup/robots/cob4-5.xml
@@ -264,7 +264,6 @@
 			</include>
 		</group>
 
-		<include file="$(find cob_bringup)/drivers/mimic.launch"/>
 		<include file="$(find cob_bringup)/components/cob4_head_camera.launch">
 			<arg name="robot" value="$(arg robot)"/>
 			<arg name="sim" value="$(arg sim)"/>
@@ -274,6 +273,11 @@
 		<include file="$(find cob_bringup)/drivers/sound.launch">
 			<arg name="robot" value="$(arg robot)"/>
 		</include>
+	</group>
+
+	<group> <!-- this is a special ground to assign DISPLAY:=0 only to the mimic node (and not to all other nodes, e.g. sound node) -->
+		<machine name="cob4-7-h1-display" address="$(arg cob4-7-h1)" env-loader="$(arg env-script).display" default="true" timeout="30"/>
+		<include file="$(find cob_bringup)/drivers/mimic.launch"/>
 	</group>
 
 	<machine name="cob4-5-b1" address="$(arg cob4-5-b1)" env-loader="$(arg env-script)" default="true" timeout="30"/>

--- a/cob_bringup/robots/cob4-5.xml
+++ b/cob_bringup/robots/cob4-5.xml
@@ -276,7 +276,7 @@
 	</group>
 
 	<group> <!-- this is a special ground to assign DISPLAY:=0 only to the mimic node (and not to all other nodes, e.g. sound node) -->
-		<machine name="cob4-7-h1-display" address="$(arg cob4-7-h1)" env-loader="$(arg env-script).display" default="true" timeout="30"/>
+		<machine name="cob4-5-h1-display" address="$(arg cob4-5-h1)" env-loader="$(arg env-script).display" default="true" timeout="30"/>
 		<include file="$(find cob_bringup)/drivers/mimic.launch"/>
 	</group>
 

--- a/cob_bringup/robots/cob4-7.xml
+++ b/cob_bringup/robots/cob4-7.xml
@@ -255,7 +255,7 @@
 		</include>
 	</group>
 
-	<group> <!-- this is a special ground to assign DISPLAY:=0 only to the mimic node (and not to all other nodes, e.g. sound node) -->
+	<group> <!-- this is a special group to assign DISPLAY:=0 only to the mimic node (and not to all other nodes, e.g. sound node) -->
 		<machine name="cob4-7-h1-display" address="$(arg cob4-7-h1)" env-loader="$(arg env-script).display" default="true" timeout="30"/>
 		<include file="$(find cob_bringup)/drivers/mimic.launch"/>
 	</group>

--- a/cob_bringup/robots/cob4-7.xml
+++ b/cob_bringup/robots/cob4-7.xml
@@ -244,7 +244,6 @@
 			</include>
 		</group>
 
-		<include file="$(find cob_bringup)/drivers/mimic.launch"/>
 		<include file="$(find cob_bringup)/components/cob4_head_camera.launch">
 			<arg name="robot" value="$(arg robot)"/>
 			<arg name="sim" value="$(arg sim)"/>
@@ -254,6 +253,11 @@
 		<include file="$(find cob_bringup)/drivers/sound.launch">
 			<arg name="robot" value="$(arg robot)"/>
 		</include>
+	</group>
+
+	<group> <!-- this is a special ground to assign DISPLAY:=0 only to the mimic node (and not to all other nodes, e.g. sound node) -->
+		<machine name="cob4-7-h1-display" address="$(arg cob4-7-h1)" env-loader="$(arg env-script).display" default="true" timeout="30"/>
+		<include file="$(find cob_bringup)/drivers/mimic.launch"/>
 	</group>
 
 	<machine name="cob4-7-b1" address="$(arg cob4-7-b1)" env-loader="$(arg env-script)" default="true" timeout="30"/>

--- a/cob_bringup/robots/cob4-8.xml
+++ b/cob_bringup/robots/cob4-8.xml
@@ -258,7 +258,6 @@
 			</include>
 		</group>
 
-		<include file="$(find cob_bringup)/drivers/mimic.launch"/>
 		<include file="$(find cob_bringup)/components/cob4_head_camera.launch">
 			<arg name="robot" value="$(arg robot)"/>
 			<arg name="sim" value="$(arg sim)"/>
@@ -268,6 +267,11 @@
 		<include file="$(find cob_bringup)/drivers/sound.launch">
 			<arg name="robot" value="$(arg robot)"/>
 		</include>
+	</group>
+
+	<group> <!-- this is a special ground to assign DISPLAY:=0 only to the mimic node (and not to all other nodes, e.g. sound node) -->
+		<machine name="cob4-7-h1-display" address="$(arg cob4-7-h1)" env-loader="$(arg env-script).display" default="true" timeout="30"/>
+		<include file="$(find cob_bringup)/drivers/mimic.launch"/>
 	</group>
 
 	<machine name="cob4-8-b1" address="$(arg cob4-8-b1)" env-loader="$(arg env-script)" default="true" timeout="30"/>

--- a/cob_bringup/robots/cob4-8.xml
+++ b/cob_bringup/robots/cob4-8.xml
@@ -269,7 +269,7 @@
 		</include>
 	</group>
 
-	<group> <!-- this is a special ground to assign DISPLAY:=0 only to the mimic node (and not to all other nodes, e.g. sound node) -->
+	<group> <!-- this is a special group to assign DISPLAY:=0 only to the mimic node (and not to all other nodes, e.g. sound node) -->
 		<machine name="cob4-8-h1-display" address="$(arg cob4-8-h1)" env-loader="$(arg env-script).display" default="true" timeout="30"/>
 		<include file="$(find cob_bringup)/drivers/mimic.launch"/>
 	</group>

--- a/cob_bringup/robots/cob4-8.xml
+++ b/cob_bringup/robots/cob4-8.xml
@@ -270,7 +270,7 @@
 	</group>
 
 	<group> <!-- this is a special ground to assign DISPLAY:=0 only to the mimic node (and not to all other nodes, e.g. sound node) -->
-		<machine name="cob4-7-h1-display" address="$(arg cob4-7-h1)" env-loader="$(arg env-script).display" default="true" timeout="30"/>
+		<machine name="cob4-8-h1-display" address="$(arg cob4-8-h1)" env-loader="$(arg env-script).display" default="true" timeout="30"/>
 		<include file="$(find cob_bringup)/drivers/mimic.launch"/>
 	</group>
 


### PR DESCRIPTION
enables only mimic to use `export DISPLAY:=0` but not sound 