### PR TITLE
single computer for raw, fix ports

### DIFF
--- a/cob_bringup/robots/raw3-3.launch
+++ b/cob_bringup/robots/raw3-3.launch
@@ -4,8 +4,6 @@
 	<arg name="env-script" default="$(find cob_bringup)/env.sh"/>
 
 	<include file="$(find cob_bringup)/robots/raw3-3.xml">
-		<arg name="pc1" value="raw3-3-pc1"/>
-		<arg name="pc2" value="raw3-3-pc2"/>
 		<arg name="env-script" value="$(arg env-script)"/>
 	</include>
 

--- a/cob_bringup/robots/raw3-3.xml
+++ b/cob_bringup/robots/raw3-3.xml
@@ -79,26 +79,14 @@
 		</include>
 		<include file="$(find cob_script_server)/launch/script_server.launch"/>
 
-		<!-- simulation only -->
-		<include if="$(arg sim)" file="$(find cob_bringup)/tools/fake_diagnostics.launch">
-			<arg name="fake_diagnostics" value="'base_laser_front, base_laser_rear, -pc1, -pc2, -pc3, joy'"/>
-		</include>
-	</group>
-
-	<group>
-		<machine name="pc2" address="$(arg pc2)" env-loader="$(arg env-script)" default="true" timeout="30"/>
-
-		<!-- start hardware -->
-		<group unless="$(arg sim)">
-			<include file="$(find cob_bringup)/tools/pc_monitor.launch">
-				<arg name="robot" value="$(arg robot)"/>
-				<arg name="pc" value="$(arg pc2)"/>
-			</include>
-		</group>
-
 		<include file="$(find cob_bringup)/drivers/light.launch">
 			<arg name="robot" value="$(arg robot)"/>
 			<arg name="sim_enabled" value="$(arg sim)"/>
+		</include>
+		
+		<!-- simulation only -->
+		<include if="$(arg sim)" file="$(find cob_bringup)/tools/fake_diagnostics.launch">
+			<arg name="fake_diagnostics" value="'base_laser_front, base_laser_rear, -pc1, -pc2, -pc3, joy'"/>
 		</include>
 	</group>
 

--- a/cob_bringup/tools/autoinit.launch
+++ b/cob_bringup/tools/autoinit.launch
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<launch>
+	<node pkg="cob_helper_tools" type="auto_init.py" name="auto_init" output="screen">
+		<rosparam param="components">[base]</rosparam>
+	</node>
+
+	<node pkg="cob_helper_tools" type="auto_recover.py" name="auto_recover" output="screen">
+		<rosparam param="components">[base]</rosparam>
+	</node>
+</launch>

--- a/cob_hardware_config/robots/raw3-3/config/base_laser_front.yaml
+++ b/cob_hardware_config/robots/raw3-3/config/base_laser_front.yaml
@@ -1,4 +1,4 @@
-port: /dev/ttyUSB1
+port: /dev/ttyScan1
 baud: 500000
 scan_duration: 0.025 #no info about that in SICK-docu, but 0.025 is believable and looks good in rviz
 scan_cycle_time: 0.040 #SICK-docu says S300 scans every 40ms

--- a/cob_hardware_config/robots/raw3-3/config/base_laser_rear.yaml
+++ b/cob_hardware_config/robots/raw3-3/config/base_laser_rear.yaml
@@ -1,4 +1,4 @@
-port: /dev/ttyUSB0
+port: /dev/ttyScan0
 baud: 500000
 scan_duration: 0.025 #no info about that in SICK-docu, but 0.025 is believable and looks good in rviz
 scan_cycle_time: 0.040 #SICK-docu says S300 scans every 40ms

--- a/cob_hardware_config/robots/raw3-3/config/light.yaml
+++ b/cob_hardware_config/robots/raw3-3/config/light.yaml
@@ -1,5 +1,5 @@
 devicedriver: ms-35
-devicestring: /dev/ttyUSB2
+devicestring: /dev/ttyLED
 baudrate: 38400
 invert_output: false
 pubmarker: false

--- a/cob_hardware_config/robots/raw3-3/config/light.yaml
+++ b/cob_hardware_config/robots/raw3-3/config/light.yaml
@@ -1,5 +1,5 @@
 devicedriver: ms-35
-devicestring: /dev/ttyUSB0
+devicestring: /dev/ttyUSB2
 baudrate: 38400
 invert_output: false
 pubmarker: false


### PR DESCRIPTION
Migrate raw3-3 to kinetic. Because now only one pc is used for all the "hardware" stuff the interface names changed for "light" and we use "ttyScanX" because it has read and write permissions for all users thanks to [99-cob.rules](https://github.com/ipa320/setup/blob/master/udev_rules/99-cob.rules)