### PR TITLE
do not monitor ntp offset for base pcs

### DIFF
--- a/cob_bringup/robots/cob4-10.xml
+++ b/cob_bringup/robots/cob4-10.xml
@@ -35,7 +35,7 @@
 			<include file="$(find cob_bringup)/tools/pc_monitor.launch">
 				<arg name="robot" value="$(arg robot)"/>
 				<arg name="pc" value="$(arg cob4-10-b1)"/>
-				<arg name="ntp_server" value="de.pool.ntp.org"/>
+				<arg name="enable_ntp_monitoring" value="false"/>
 			</include>
 		</group>
 

--- a/cob_bringup/robots/cob4-11.xml
+++ b/cob_bringup/robots/cob4-11.xml
@@ -24,7 +24,7 @@
 			<include file="$(find cob_bringup)/tools/pc_monitor.launch">
 				<arg name="robot" value="$(arg robot)"/>
 				<arg name="pc" value="$(arg cob4-11-b1)"/>
-				<arg name="ntp_server" value="de.pool.ntp.org"/>
+				<arg name="enable_ntp_monitoring" value="false"/>
 			</include>
 		</group>
 

--- a/cob_bringup/robots/cob4-2.xml
+++ b/cob_bringup/robots/cob4-2.xml
@@ -35,7 +35,7 @@
 			<include file="$(find cob_bringup)/tools/pc_monitor.launch">
 				<arg name="robot" value="$(arg robot)"/>
 				<arg name="pc" value="$(arg cob4-2-b1)"/>
-				<arg name="ntp_server" value="de.pool.ntp.org"/>
+				<arg name="enable_ntp_monitoring" value="false"/>
 			</include>
 		</group>
 

--- a/cob_bringup/robots/cob4-3.xml
+++ b/cob_bringup/robots/cob4-3.xml
@@ -23,7 +23,7 @@
 			<include file="$(find cob_bringup)/tools/pc_monitor.launch">
 				<arg name="robot" value="$(arg robot)"/>
 				<arg name="pc" value="$(arg cob4-3-b1)"/>
-				<arg name="ntp_server" value="de.pool.ntp.org"/>
+				<arg name="enable_ntp_monitoring" value="false"/>
 			</include>
 		</group>
 

--- a/cob_bringup/robots/cob4-4.xml
+++ b/cob_bringup/robots/cob4-4.xml
@@ -24,7 +24,7 @@
 			<include file="$(find cob_bringup)/tools/pc_monitor.launch">
 				<arg name="robot" value="$(arg robot)"/>
 				<arg name="pc" value="$(arg cob4-4-b1)"/>
-				<arg name="ntp_server" value="de.pool.ntp.org"/>
+				<arg name="enable_ntp_monitoring" value="false"/>
 			</include>
 		</group>
 

--- a/cob_bringup/robots/cob4-5.xml
+++ b/cob_bringup/robots/cob4-5.xml
@@ -35,7 +35,7 @@
 			<include file="$(find cob_bringup)/tools/pc_monitor.launch">
 				<arg name="robot" value="$(arg robot)"/>
 				<arg name="pc" value="$(arg cob4-5-b1)"/>
-				<arg name="ntp_server" value="de.pool.ntp.org"/>
+				<arg name="enable_ntp_monitoring" value="false"/>
 			</include>
 		</group>
 

--- a/cob_bringup/robots/cob4-6.xml
+++ b/cob_bringup/robots/cob4-6.xml
@@ -24,7 +24,7 @@
 			<include file="$(find cob_bringup)/tools/pc_monitor.launch">
 				<arg name="robot" value="$(arg robot)"/>
 				<arg name="pc" value="$(arg cob4-6-b1)"/>
-				<arg name="ntp_server" value="de.pool.ntp.org"/>
+				<arg name="enable_ntp_monitoring" value="false"/>
 			</include>
 		</group>
 

--- a/cob_bringup/robots/cob4-7.xml
+++ b/cob_bringup/robots/cob4-7.xml
@@ -35,7 +35,7 @@
 			<include file="$(find cob_bringup)/tools/pc_monitor.launch">
 				<arg name="robot" value="$(arg robot)"/>
 				<arg name="pc" value="$(arg cob4-7-b1)"/>
-				<arg name="ntp_server" value="de.pool.ntp.org"/>
+				<arg name="enable_ntp_monitoring" value="false"/>
 			</include>
 		</group>
 

--- a/cob_bringup/robots/cob4-8.xml
+++ b/cob_bringup/robots/cob4-8.xml
@@ -35,7 +35,7 @@
 			<include file="$(find cob_bringup)/tools/pc_monitor.launch">
 				<arg name="robot" value="$(arg robot)"/>
 				<arg name="pc" value="$(arg cob4-8-b1)"/>
-				<arg name="ntp_server" value="de.pool.ntp.org"/>
+				<arg name="enable_ntp_monitoring" value="false"/>
 			</include>
 		</group>
 

--- a/cob_bringup/robots/cob4-9.xml
+++ b/cob_bringup/robots/cob4-9.xml
@@ -24,7 +24,7 @@
 			<include file="$(find cob_bringup)/tools/pc_monitor.launch">
 				<arg name="robot" value="$(arg robot)"/>
 				<arg name="pc" value="$(arg cob4-9-b1)"/>
-				<arg name="ntp_server" value="de.pool.ntp.org"/>
+				<arg name="enable_ntp_monitoring" value="false"/>
 			</include>
 		</group>
 

--- a/cob_bringup/robots/raw3-1.xml
+++ b/cob_bringup/robots/raw3-1.xml
@@ -26,7 +26,7 @@
 			<include file="$(find cob_bringup)/tools/pc_monitor.launch">
 				<arg name="robot" value="$(arg robot)"/>
 				<arg name="pc" value="$(arg pc1)"/>
-				<arg name="ntp_server" value="de.pool.ntp.org"/>
+				<arg name="enable_ntp_monitoring" value="false"/>
 			</include>
 			<!--include file="$(find cob_bringup)/tools/wifi_monitor.launch">
 				<arg name="robot" value="$(arg robot)"/>

--- a/cob_bringup/robots/raw3-3.xml
+++ b/cob_bringup/robots/raw3-3.xml
@@ -26,7 +26,7 @@
 			<include file="$(find cob_bringup)/tools/pc_monitor.launch">
 				<arg name="robot" value="$(arg robot)"/>
 				<arg name="pc" value="$(arg pc1)"/>
-				<arg name="ntp_server" value="de.pool.ntp.org"/>
+				<arg name="enable_ntp_monitoring" value="false"/>
 			</include>
 			<include file="$(find cob_bringup)/drivers/phidgets.launch">
 				<arg name="robot" value="$(arg robot)"/>

--- a/cob_bringup/robots/raw3-5.xml
+++ b/cob_bringup/robots/raw3-5.xml
@@ -24,7 +24,7 @@
 			<include file="$(find cob_bringup)/tools/pc_monitor.launch">
 				<arg name="robot" value="$(arg robot)"/>
 				<arg name="pc" value="$(arg pc1)"/>
-				<arg name="ntp_server" value="de.pool.ntp.org"/>
+				<arg name="enable_ntp_monitoring" value="false"/>
 			</include>
 			<include file="$(find cob_bringup)/drivers/phidgets.launch">
 				<arg name="robot" value="$(arg robot)"/>

--- a/cob_bringup/tools/pc_monitor.launch
+++ b/cob_bringup/tools/pc_monitor.launch
@@ -5,7 +5,8 @@
 	<arg name="pkg_hardware_config" default="$(find cob_hardware_config)"/>
 	<arg name="pc" default="localhost"/>
 	<arg name="diag_hostname" default="$(arg pc)"/>
-	<arg name="ntp_server" default="localhost"/>
+	<arg name="enable_ntp_monitoring" default="true"/>
+	<arg name="ntp_server" default="de.pool.ntp.org"/>
 
 	<!-- Monitor CPU (temp, usage) -->
 	<node pkg="cob_monitoring" name="$(anon cpu_monitor)" type="cpu_monitor.py" args="--diag-hostname=$(arg diag_hostname)" output="screen">
@@ -16,7 +17,7 @@
 	<node pkg="cob_monitoring" name="$(anon hd_monitor)" type="hd_monitor.py" args="--diag-hostname=$(arg diag_hostname)" output="screen"/>
 
 	<!-- Monitor ntp -->
-	<node pkg="cob_monitoring" name="$(anon ntp_monitor)" type="ntp_monitor.py" args="$(arg ntp_server) --diag-hostname=$(arg diag_hostname)" output="screen">
+	<node if="$(arg enable_ntp_monitoring)" pkg="cob_monitoring" name="$(anon ntp_monitor)" type="ntp_monitor.py" args="$(arg ntp_server) --diag-hostname=$(arg diag_hostname)" output="screen">
 		<rosparam command="load" file="$(arg pkg_hardware_config)/robots/$(arg robot)/config/ntp_monitor.yaml"/>
 	</node>
 


### PR DESCRIPTION
fixes https://github.com/ipa320/cob_command_tools/issues/204

 - prevents diagnostic error when offline, i.e. ntp_server not reachable....
 - also calling `ntpdate localhost` fails -> changing default ntp_server to `de.pool.ntp.org`