### PR TITLE
use homing offsets from cob4-2 for cob4-7

### DIFF
--- a/cob_hardware_config/robots/cob4-7/config/base_driver.yaml
+++ b/cob_hardware_config/robots/cob4-7/config/base_driver.yaml
@@ -1,12 +1,12 @@
 nodes:
   fl_caster_rotation_joint:
     dcf_overlay: # "ObjectID" : "ParameterValue" (both as strings)
-      "607C": "-48238.5" # home offset
+      "607C": "39567" # home offset
 
   b_caster_rotation_joint:
     dcf_overlay: # "ObjectID" : "ParameterValue" (both as strings)
-      "607C": "-167845" # home offset
+      "607C": "-77479" # home offset
 
   fr_caster_rotation_joint:
     dcf_overlay: # "ObjectID" : "ParameterValue" (both as strings)
-      "607C": "71958.5" # home offset
+      "607C": "160844" # home offset


### PR DESCRIPTION
switched bases. cob4-7 is now cob4-2 and cob4-2 is cob4-7
(see https://github.com/unity-robotics/unity_robots/pull/12)
