### PR TITLE
fix nodelet and topic namespaces

### DIFF
--- a/cob_bringup/components/cam3d_openni2.launch
+++ b/cob_bringup/components/cam3d_openni2.launch
@@ -5,7 +5,6 @@
 	<arg name="device_id" default="#1"/>
 	<arg name="data_skip" default="0"/>
 	<arg name="num_worker_threads" default="4"/>
-	<arg name="start_manager" default="true"/>
 	<arg name="throttle" default="false"/>
 	<arg name="flip" default="true"/>
 	<arg name="sim" default="false"/>
@@ -17,23 +16,27 @@
 		<arg name="data_skip" value="$(arg data_skip)"/>
 		<arg name="num_worker_threads" value="$(arg num_worker_threads)"/>
 	</include>
-	<include file="$(find cob_bringup)/tools/hz_monitor.launch">
-		<arg name="robot" value="$(arg robot)"/>
-		<arg name="yaml_name" value="$(arg name)"/>
-		<arg name="sim" value="$(arg sim)"/>
-	</include>
-	<include if="$(arg flip)" file="$(find cob_bringup)/drivers/image_flip_nodelet.launch">
-		<arg name="robot" value="$(arg robot)"/>
-		<arg name="camera_name" value="$(arg name)"/>
-		<arg name="nodelet_manager" value="$(arg name)_nodelet_manager"/>
-		<arg name="start_manager" value="$(arg start_manager)"/>
-	</include>
-	<include if="$(arg throttle)" file="$(find cob_cam3d_throttle)/launch/cam3d_throttle.launch" >
-		<arg name="namespace" value="$(arg name)" />
-		<arg name="rate" value="1.0" />
-		<arg name="start_manager" value="$(arg start_manager)"/>
-		<arg name="nodelet_manager" value="$(arg name)_nodelet_manager"/>
-	</include>
+	<group ns="$(arg name)">
+		<include file="$(find cob_bringup)/tools/hz_monitor.launch">
+			<arg name="robot" value="$(arg robot)"/>
+			<arg name="yaml_name" value="$(arg name)"/>
+			<arg name="sim" value="$(arg sim)"/>
+		</include>
+		<include if="$(arg flip)" file="$(find cob_bringup)/drivers/image_flip_nodelet.launch">
+			<arg name="robot" value="$(arg robot)"/>
+			<arg name="camera_name" value="$(arg name)"/>
+			<arg name="nodelet_manager" value="$(arg name)_nodelet_manager"/>
+			<arg name="start_manager" value="false"/>
+			<arg name="pointcloud_in" default="/$(arg name)/depth_registered/points"/>
+			<arg name="pointcloud_out" default="/$(arg name)_upright/depth_registered/points"/>
+		</include>
+		<include if="$(arg throttle)" file="$(find cob_cam3d_throttle)/launch/cam3d_throttle.launch" >
+			<arg name="namespace" value="$(arg name)" />
+			<arg name="rate" value="1.0" />
+			<arg name="nodelet_manager" value="$(arg name)_nodelet_manager"/>
+			<arg name="start_manager" value="false"/>
+		</include>
+	</group>
 
 
 	<group ns="$(arg name)" if="$(arg sim)">
@@ -60,7 +63,7 @@
 
 		<!-- start nodelet manager in simulation -->
 		<node pkg="nodelet" type="nodelet" name="$(arg name)_nodelet_manager" args="manager" output="screen">
-			<param name="num_worker_threads" value="2" />
+			<param name="num_worker_threads" value="$(arg num_worker_threads)" />
 		</node>
 	</group>
 </launch>

--- a/cob_bringup/components/cam3d_r200_rgbd.launch
+++ b/cob_bringup/components/cam3d_r200_rgbd.launch
@@ -3,7 +3,6 @@
 	<arg name="robot"/>
 	<arg name="name"/>
 	<arg name="num_worker_threads" default="4"/>
-	<arg name="start_manager" default="true"/>
 	<arg name="flip" default="true"/>
 	<arg name="sim" default="false"/>
 	<arg name="serial_no" default=""/>
@@ -13,18 +12,21 @@
 		<arg name="num_worker_threads" value="$(arg num_worker_threads)" />
 		<arg name="serial_no" value="$(arg serial_no)" />
 	</include>
-	<include file="$(find cob_bringup)/tools/hz_monitor.launch">
-		<arg name="robot" value="$(arg robot)"/>
-		<arg name="yaml_name" value="$(arg name)"/>
-		<arg name="sim" value="$(arg sim)"/>
-	</include>
-	<include if="$(arg flip)" file="$(find cob_bringup)/drivers/image_flip_nodelet.launch">
-		<arg name="robot" value="$(arg robot)"/>
-		<arg name="camera_name" value="$(arg name)"/>
-		<arg name="nodelet_manager" value="$(arg name)_nodelet_manager"/>
-		<arg name="start_manager" value="$(arg start_manager)"/>
-	</include>
-
+	<group ns="$(arg name)">
+		<include file="$(find cob_bringup)/tools/hz_monitor.launch">
+			<arg name="robot" value="$(arg robot)"/>
+			<arg name="yaml_name" value="$(arg name)"/>
+			<arg name="sim" value="$(arg sim)"/>
+		</include>
+		<include if="$(arg flip)" file="$(find cob_bringup)/drivers/image_flip_nodelet.launch">
+			<arg name="robot" value="$(arg robot)"/>
+			<arg name="camera_name" value="$(arg name)"/>
+			<arg name="nodelet_manager" value="$(arg name)_nodelet_manager"/>
+			<arg name="start_manager" value="false"/>
+			<arg name="pointcloud_in" value="/$(arg name)/depth/points"/>
+			<arg name="pointcloud_out" value="/$(arg name)_upright/depth/points"/>
+		</include>
+	</group>
 
 	<group ns="$(arg name)" if="$(arg sim)">
 		<!-- static frames broadcasted by camera driver -->
@@ -40,20 +42,9 @@
 		<node pkg="tf2_ros" type="static_transform_publisher" name="stp_ir2_frame" args="0.0 -0.011 0.0 0.0 0.0 0.0 1.0 /$(arg name)_link /$(arg name)_ir2_frame"/>
 		<node pkg="tf2_ros" type="static_transform_publisher" name="stp_ir2_optical_frame" args="0.0 0.0 0.0 -0.5 0.5 -0.5 0.5 /$(arg name)_ir2_frame /$(arg name)_ir2_optical_frame"/>
 
-		<!-- relay additional topics not available from sensor plugin -->
-		<node pkg="topic_tools" type="relay" name="camera_info_relay" args="depth_registered/camera_info depth/camera_info">
-			<param name="lazy" value="true"/>
-		</node>
-		<node pkg="topic_tools" type="relay" name="image_raw_relay" args="depth_registered/image_raw depth/image_raw">
-			<param name="lazy" value="true"/>
-		</node>
-		<node pkg="topic_tools" type="relay" name="points_relay" args="depth_registered/points depth/points">
-			<param name="lazy" value="true"/>
-		</node>
-
 		<!-- start nodelet manager in simulation -->
 		<node pkg="nodelet" type="nodelet" name="$(arg name)_nodelet_manager" args="manager" output="screen">
-			<param name="num_worker_threads" value="2" />
+			<param name="num_worker_threads" value="$(arg num_worker_threads)" />
 		</node>
 	</group>
 </launch>

--- a/cob_bringup/components/cam3d_zr300_rgbd.launch
+++ b/cob_bringup/components/cam3d_zr300_rgbd.launch
@@ -3,7 +3,6 @@
 	<arg name="robot"/>
 	<arg name="name"/>
 	<arg name="num_worker_threads" default="4"/>
-	<arg name="start_manager" default="true"/>
 	<arg name="flip" default="true"/>
 	<arg name="sim" default="false"/>
 	<arg name="serial_no" default=""/>
@@ -13,17 +12,21 @@
 		<arg name="num_worker_threads" value="$(arg num_worker_threads)" />
 		<arg name="serial_no" value="$(arg serial_no)"/>
 	</include>
-	<include file="$(find cob_bringup)/tools/hz_monitor.launch">
-		<arg name="robot" value="$(arg robot)"/>
-		<arg name="yaml_name" value="$(arg name)"/>
-		<arg name="sim" value="$(arg sim)"/>
-	</include>
-	<include if="$(arg flip)" file="$(find cob_bringup)/drivers/image_flip_nodelet.launch">
-		<arg name="robot" value="$(arg robot)"/>
-		<arg name="camera_name" value="$(arg name)"/>
-		<arg name="nodelet_manager" value="$(arg name)_nodelet_manager"/>
-		<arg name="start_manager" value="$(arg start_manager)"/>
-	</include>
+	<group ns="$(arg name)">
+		<include file="$(find cob_bringup)/tools/hz_monitor.launch">
+			<arg name="robot" value="$(arg robot)"/>
+			<arg name="yaml_name" value="$(arg name)"/>
+			<arg name="sim" value="$(arg sim)"/>
+		</include>
+		<include if="$(arg flip)" file="$(find cob_bringup)/drivers/image_flip_nodelet.launch">
+			<arg name="robot" value="$(arg robot)"/>
+			<arg name="camera_name" value="$(arg name)"/>
+			<arg name="nodelet_manager" value="$(arg name)_nodelet_manager"/>
+			<arg name="start_manager" value="false"/>
+			<arg name="pointcloud_in" value="/$(arg name)/depth/points"/>
+			<arg name="pointcloud_out" value="/$(arg name)_upright/depth/points"/>
+		</include>
+	</group>
 
 	<group ns="$(arg name)" if="$(arg sim)">
 		<!-- static frames broadcasted by camera driver -->
@@ -46,20 +49,9 @@
 		<node pkg="tf2_ros" type="static_transform_publisher" name="stp_fisheye_frame" args="0.0 0.088 0.0 0.0 0.0 0.0 1.0 /$(arg name)_link /$(arg name)_fisheye_frame"/>
 		<node pkg="tf2_ros" type="static_transform_publisher" name="stp_fisheye_optical_frame" args="0.0 0.0 0.0 -0.5 0.5 -0.5 0.5 /$(arg name)_fisheye_frame /$(arg name)_fisheye_optical_frame"/>
 
-		<!-- relay additional topics not available from sensor plugin -->
-		<node pkg="topic_tools" type="relay" name="camera_info_relay" args="depth_registered/camera_info depth/camera_info">
-			<param name="lazy" value="true"/>
-		</node>
-		<node pkg="topic_tools" type="relay" name="image_raw_relay" args="depth_registered/image_raw depth/image_raw">
-			<param name="lazy" value="true"/>
-		</node>
-		<node pkg="topic_tools" type="relay" name="points_relay" args="depth_registered/points depth/points">
-			<param name="lazy" value="true"/>
-		</node>
-
 		<!-- start nodelet manager in simulation -->
 		<node pkg="nodelet" type="nodelet" name="$(arg name)_nodelet_manager" args="manager" output="screen">
-			<param name="num_worker_threads" value="2" />
+			<param name="num_worker_threads" value="$(arg num_worker_threads)" />
 		</node>
 	</group>
 </launch>

--- a/cob_bringup/drivers/image_flip.launch
+++ b/cob_bringup/drivers/image_flip.launch
@@ -10,7 +10,7 @@
 	<arg name="colorimage_out" default="/$(arg camera_name)_upright/rgb/image_raw"/>
 
 	<!-- sensor message gateway node (forwards sensor messages in a desired rate) -->
-	<node ns="image_flip_$(arg camera_name)" pkg="cob_image_flip" type="image_flip" name="image_flip_$(arg camera_name)" output="screen">
+	<node ns="$(arg camera_name)" pkg="cob_image_flip" type="image_flip" name="image_flip_$(arg camera_name)" output="screen">
 		<rosparam command="load" file="$(arg pkg_hardware_config)/robots/$(arg robot)/config/image_flip_params_$(arg camera_name).yaml"/>
 		<remap from="~pointcloud_in" to="$(arg pointcloud_in)"/>
 		<remap from="~pointcloud_out" to="$(arg pointcloud_out)"/>

--- a/cob_bringup/drivers/image_flip_nodelet.launch
+++ b/cob_bringup/drivers/image_flip_nodelet.launch
@@ -12,9 +12,9 @@
 	<arg name="start_manager" default="true"/>
 
 
-	<node if="$(arg start_manager)" ns="image_flip_$(arg camera_name)" pkg="nodelet" type="nodelet" name="$(arg nodelet_manager)" args="manager" output="screen"/>
+	<node if="$(arg start_manager)" pkg="nodelet" type="nodelet" name="$(arg nodelet_manager)" args="manager" output="screen"/>
 
-	<node ns="image_flip_$(arg camera_name)" pkg="nodelet" type="nodelet" name="image_flip_$(arg camera_name)_nodelet" args="load cob_image_flip/ImageFlipNodelet /$(arg camera_name)/$(arg nodelet_manager)" output="screen">
+	<node pkg="nodelet" type="nodelet" name="image_flip_nodelet" args="load cob_image_flip/ImageFlipNodelet $(arg nodelet_manager)" output="screen">
 		<rosparam command="load" file="$(arg pkg_hardware_config)/robots/$(arg robot)/config/image_flip_params_$(arg camera_name).yaml"/>
 		<remap from="~pointcloud_in" to="$(arg pointcloud_in)"/>
 		<remap from="~pointcloud_out" to="$(arg pointcloud_out)"/>

--- a/cob_bringup/robots/cob4-10.xml
+++ b/cob_bringup/robots/cob4-10.xml
@@ -162,7 +162,6 @@
 			<arg name="device_id" value="#1"/>
 			<arg name="data_skip" value="0"/>
 			<arg name="num_worker_threads" value="2"/>
-			<arg name="start_manager" value="false"/>
 			<arg name="sim" value="$(arg sim)"/>
 		</include>
 
@@ -189,7 +188,6 @@
 			<arg name="robot" value="$(arg robot)"/>
 			<arg name="name" value="torso_cam3d_down"/>
 			<arg name="num_worker_threads" value="2"/>
-			<arg name="start_manager" value="false"/>
 			<arg name="sim" value="$(arg sim)"/>
 		</include>
 	</group>
@@ -212,7 +210,6 @@
 			<arg name="device_id" value="#1"/>
 			<arg name="data_skip" value="0"/>
 			<arg name="num_worker_threads" value="2"/>
-			<arg name="start_manager" value="false"/>
 			<arg name="sim" value="$(arg sim)"/>
 		</include>
 
@@ -247,7 +244,6 @@
 			<arg name="device_id" value="#1"/>
 			<arg name="data_skip" value="0"/>
 			<arg name="num_worker_threads" value="2"/>
-			<arg name="start_manager" value="false"/>
 			<arg name="sim" value="$(arg sim)"/>
 		</include>
 	</group>

--- a/cob_bringup/robots/cob4-16.xml
+++ b/cob_bringup/robots/cob4-16.xml
@@ -176,7 +176,6 @@
 			<arg name="robot" value="$(arg robot)"/>
 			<arg name="name" value="torso_cam3d_left"/>
 			<arg name="num_worker_threads" value="2"/>
-			<arg name="start_manager" value="false"/>
 			<arg name="sim" value="$(arg sim)"/>
 		</include>
 
@@ -203,7 +202,6 @@
 			<arg name="robot" value="$(arg robot)"/>
 			<arg name="name" value="torso_cam3d_down"/>
 			<arg name="num_worker_threads" value="2"/>
-			<arg name="start_manager" value="false"/>
 			<arg name="sim" value="$(arg sim)"/>
 		</include>
 	</group>
@@ -224,7 +222,6 @@
 			<arg name="robot" value="$(arg robot)"/>
 			<arg name="name" value="torso_cam3d_right"/>
 			<arg name="num_worker_threads" value="2"/>
-			<arg name="start_manager" value="false"/>
 			<arg name="sim" value="$(arg sim)"/>
 		</include>
 
@@ -252,7 +249,6 @@
 			<arg name="name" value="sensorring_cam3d"/>
 			<arg name="device_id" value="#1"/>
 			<arg name="data_skip" value="0"/>
-			<arg name="start_manager" value="false"/>
 			<arg name="sim" value="$(arg sim)"/>
 		</include>
 	</group>

--- a/cob_bringup/robots/cob4-5.xml
+++ b/cob_bringup/robots/cob4-5.xml
@@ -169,7 +169,6 @@
 			<arg name="name" value="torso_cam3d_right"/>
 			<arg name="device_id" value="#1"/>
 			<arg name="data_skip" value="0"/>
-			<arg name="start_manager" value="false"/>
 			<arg name="sim" value="$(arg sim)"/>
 		</include>
 
@@ -196,7 +195,6 @@
 			<arg name="robot" value="$(arg robot)"/>
 			<arg name="name" value="torso_cam3d_down"/>
 			<arg name="num_worker_threads" value="2"/>
-			<arg name="start_manager" value="false"/>
 			<arg name="sim" value="$(arg sim)"/>
 		</include>
 	</group>
@@ -219,7 +217,6 @@
 			<arg name="device_id" value="#1"/>
 			<arg name="data_skip" value="0"/>
 			<arg name="num_worker_threads" value="2"/>
-			<arg name="start_manager" value="false"/>
 			<arg name="sim" value="$(arg sim)"/>
 		</include>
 
@@ -253,7 +250,6 @@
 			<arg name="name" value="sensorring_cam3d_back"/>
 			<arg name="device_id" value="#1"/>
 			<arg name="data_skip" value="0"/>
-			<arg name="start_manager" value="false"/>
 			<arg name="sim" value="$(arg sim)"/>
 		</include>
 	</group>

--- a/cob_bringup/robots/cob4-7.xml
+++ b/cob_bringup/robots/cob4-7.xml
@@ -149,7 +149,6 @@
 			<arg name="robot" value="$(arg robot)"/>
 			<arg name="name" value="torso_cam3d_left"/>
 			<arg name="num_worker_threads" value="2"/>
-			<arg name="start_manager" value="false"/>
 			<arg name="sim" value="$(arg sim)"/>
 		</include>
 		<include file="$(find cob_bringup)/drivers/light.launch">
@@ -202,7 +201,6 @@
 			<arg name="robot" value="$(arg robot)"/>
 			<arg name="name" value="torso_cam3d_down"/>
 			<arg name="num_worker_threads" value="2"/>
-			<arg name="start_manager" value="false"/>
 			<arg name="sim" value="$(arg sim)"/>
 		</include>
 	</group>
@@ -222,7 +220,6 @@
 			<arg name="robot" value="$(arg robot)"/>
 			<arg name="name" value="torso_cam3d_right"/>
 			<arg name="num_worker_threads" value="2"/>
-			<arg name="start_manager" value="false"/>
 			<arg name="sim" value="$(arg sim)"/>
 		</include>
 	</group>

--- a/cob_bringup/robots/cob4-8.xml
+++ b/cob_bringup/robots/cob4-8.xml
@@ -169,7 +169,6 @@
 			<arg name="name" value="torso_cam3d_right"/>
 			<arg name="device_id" value="#1"/>
 			<arg name="data_skip" value="0"/>
-			<arg name="start_manager" value="false"/>
 			<arg name="sim" value="$(arg sim)"/>
 		</include>
 
@@ -196,7 +195,6 @@
 			<arg name="robot" value="$(arg robot)"/>
 			<arg name="name" value="torso_cam3d_down"/>
 			<arg name="num_worker_threads" value="2"/>
-			<arg name="start_manager" value="false"/>
 			<arg name="sim" value="$(arg sim)"/>
 		</include>
 	</group>
@@ -219,7 +217,6 @@
 			<arg name="device_id" value="#1"/>
 			<arg name="data_skip" value="0"/>
 			<arg name="num_worker_threads" value="2"/>
-			<arg name="start_manager" value="false"/>
 			<arg name="sim" value="$(arg sim)"/>
 		</include>
 
@@ -247,7 +244,6 @@
 			<arg name="name" value="sensorring_cam3d"/>
 			<arg name="device_id" value="#1"/>
 			<arg name="data_skip" value="0"/>
-			<arg name="start_manager" value="false"/>
 			<arg name="sim" value="$(arg sim)"/>
 		</include>
 	</group>


### PR DESCRIPTION
fix nodelet_manager namespace and topic names for cam3d's

 - intel do not publish `depth_registered`
 - image_flip to use camera driver's nodelet_manager
