### PR TITLE
cob4-7 without arms

### DIFF
--- a/cob_hardware_config/robots/cob4-7/config/teleop.yaml
+++ b/cob_hardware_config/robots/cob4-7/config/teleop.yaml
@@ -56,7 +56,7 @@ components: {
     joint_velocity: [0.05, 0.05],
     twist_topic_name: '/torso/twist_controller/command_twist',
     twist_max_velocity: [0.3, 0.2, 0.3, 0.3, 0.2, 0.3]
-  },
+#  },
 #  sensorring: {
 #    sss_default_target: "front",
 #    velocity_topic_name: "/sensorring/joint_group_velocity_controller/command",
@@ -80,5 +80,5 @@ components: {
 #    joint_velocity: [0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05],
 #    twist_topic_name: '/arm_left/twist_controller/command_twist',
 #    twist_max_velocity: [0.3, 0.2, 0.3, 0.3, 0.2, 0.3]
-#  }
+  }
 }


### PR DESCRIPTION
current yaml has a syntax error

why is this not detected in a roslaunch-check?