### PR TITLE
[Melodic] workaround missing dependencies

### DIFF
--- a/.travis.rosinstall
+++ b/.travis.rosinstall
@@ -22,3 +22,8 @@
     local-name: cob_supported_robots
     uri: https://github.com/ipa320/cob_supported_robots.git
     version: indigo_dev
+
+- git:
+    local-name: realsense2_substitute
+    uri: https://github.com/ipa320/realsense.git
+    version: realsense2_substitute

--- a/.travis.rosinstall.melodic
+++ b/.travis.rosinstall.melodic
@@ -1,4 +1,8 @@
 - git:
+    local-name: cob_android
+    uri: https://github.com/ipa320/cob_android
+    version: indigo_dev
+- git:
     local-name: cob_calibration_data
     uri: https://github.com/ipa320/cob_calibration_data.git
     version: indigo_dev
@@ -21,6 +25,14 @@
 - git:
     local-name: cob_extern
     uri: https://github.com/ipa320/cob_extern.git
+    version: indigo_dev
+- git:
+    local-name: cob_hand
+    uri: https://github.com/ipa320/cob_hand
+    version: indigo_dev
+- git:
+    local-name: cob_navigation
+    uri: https://github.com/ipa320/cob_navigation
     version: indigo_dev
 - git:
     local-name: cob_perception_common

--- a/.travis.rosinstall.melodic
+++ b/.travis.rosinstall.melodic
@@ -34,3 +34,13 @@
     local-name: cob_supported_robots
     uri: https://github.com/ipa320/cob_supported_robots.git
     version: indigo_dev
+
+
+- git:
+    local-name: realsense
+    uri: https://github.com/IntelRealSense/realsense-ros.git
+    version: indigo-devel
+- git:
+    local-name: realsense2
+    uri: https://github.com/IntelRealSense/realsense-ros.git
+    version: development

--- a/.travis.rosinstall.melodic
+++ b/.travis.rosinstall.melodic
@@ -37,10 +37,10 @@
 
 
 - git:
-    local-name: realsense
-    uri: https://github.com/IntelRealSense/realsense-ros.git
-    version: indigo-devel
+    local-name: realsense_substitute
+    uri: https://github.com/ipa320/realsense.git
+    version: realsense_substitute
 - git:
-    local-name: realsense2
-    uri: https://github.com/IntelRealSense/realsense-ros.git
-    version: development
+    local-name: realsense2_substitute
+    uri: https://github.com/ipa320/realsense.git
+    version: realsense2_substitute

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ env:
     - ROS_DISTRO=melodic UPSTREAM_WORKSPACE=debian
 matrix:
   allow_failures:
-    - env: ROS_DISTRO=melodic UPSTREAM_WORKSPACE=file
     - env: ROS_DISTRO=melodic UPSTREAM_WORKSPACE=debian
 install:
   - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config

--- a/cob_bringup/drivers/sick_visionary_t.launch
+++ b/cob_bringup/drivers/sick_visionary_t.launch
@@ -4,7 +4,7 @@
 	<arg name="robot" default="$(optenv ROBOT !!NO_ROBOT_SET!!)"/>
 	<arg name="name" default="cam3d"/>
 
-	<node pkg="sick_visionary_t_driver" type="sick_visionary_t_driver_node" name="$(arg name)_node" output="screen">
+	<!--node pkg="sick_visionary_t_driver" type="sick_visionary_t_driver_node" name="$(arg name)_node" output="screen">
 		<param name="remote_device_ip" value="192.168.1.10"/>
 		<param name="frame_id" value="$(arg name)_optical_frame"/>
 		<remap from="$(arg name)_node/camera_info" to="$(arg name)/depth/camera_info"/>
@@ -13,6 +13,6 @@
 		<remap from="$(arg name)_node/intensity" to="$(arg name)/depth/intensity"/>
 		<remap from="$(arg name)_node/ios" to="$(arg name)/depth/ios"/>
 		<remap from="$(arg name)_node/points" to="$(arg name)/depth/points"/>
-	</node>
+	</node-->
 
 </launch>

--- a/cob_bringup/drivers/ur.launch
+++ b/cob_bringup/drivers/ur.launch
@@ -15,13 +15,13 @@
 
 	<group unless="$(arg sim)">
 		<!-- universal robot python driver -->
-		<node unless="$(arg use_modern_driver)" ns="arm/joint_trajectory_controller" pkg="ur_driver" type="driver.py" name="ur_driver" args="$(arg robot_ip) $(arg reverse_port)" output="screen">
+		<!--node unless="$(arg use_modern_driver)" ns="arm/joint_trajectory_controller" pkg="ur_driver" type="driver.py" name="ur_driver" args="$(arg robot_ip) $(arg reverse_port)" output="screen">
 			<remap from="/arm/joint_trajectory_controller/joint_states" to="/arm/joint_states"/>
 			<remap from="/arm/joint_trajectory_controller/robot_description" to="/robot_description"/>
 			<param name="min_payload" type="double" value="$(arg min_payload)"/>
 			<param name="max_payload" type="double" value="$(arg max_payload)"/>
 			<param name="prefix" value="$(arg prefix)"/>
-		</node>
+		</node-->
 		<!-- universal robot modern driver -->
 		<!--node if="$(arg use_modern_driver)" ns="arm/joint_trajectory_controller" pkg="ur_modern_driver" type="ur_driver" name="ur_driver" args="$(arg robot_ip) $(arg reverse_port)" output="screen">
 			<remap from="/arm/joint_trajectory_controller/joint_states" to="/arm/joint_states"/>

--- a/cob_bringup/package.xml
+++ b/cob_bringup/package.xml
@@ -25,7 +25,7 @@
   <exec_depend>cob_bms_driver</exec_depend>
   <exec_depend>cob_calibration_data</exec_depend>
   <exec_depend>cob_cam3d_throttle</exec_depend>
-  <exec_depend>cob_collision_monitor</exec_depend>
+  <!--exec_depend>cob_collision_monitor</exec_depend-->
   <exec_depend>cob_collision_velocity_filter</exec_depend>
   <exec_depend>cob_command_gui</exec_depend>
   <exec_depend>cob_control_mode_adapter</exec_depend>

--- a/cob_bringup/package.xml
+++ b/cob_bringup/package.xml
@@ -76,6 +76,7 @@
   <exec_depend>openni2_launch</exec_depend>
   <exec_depend>position_controllers</exec_depend>
   <exec_depend>realsense_camera</exec_depend>
+  <exec_depend>realsense2_camera</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>rosserial_python</exec_depend>
   <exec_depend>rosserial_server</exec_depend>

--- a/cob_bringup/package.xml
+++ b/cob_bringup/package.xml
@@ -76,7 +76,7 @@
   <exec_depend>openni2_launch</exec_depend>
   <exec_depend>position_controllers</exec_depend>
   <exec_depend>realsense_camera</exec_depend>
-  <exec_depend>realsense2_camera</exec_depend>
+  <!--exec_depend>realsense2_camera</exec_depend--> <!-- not released into kinetic -->
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>rosserial_python</exec_depend>
   <exec_depend>rosserial_server</exec_depend>

--- a/cob_bringup/package.xml
+++ b/cob_bringup/package.xml
@@ -82,7 +82,7 @@
   <exec_depend>rostopic</exec_depend>
   <exec_depend>rplidar_ros</exec_depend>
   <exec_depend>rviz</exec_depend>
-  <exec_depend>sick_visionary_t_driver</exec_depend>
+  <!--exec_depend>sick_visionary_t_driver</exec_depend-->
   <exec_depend>spacenav_node</exec_depend>
   <exec_depend>tf2_ros</exec_depend>
   <exec_depend>theora_image_transport</exec_depend> <!-- needed by the cameras to publish the compressed topics -->

--- a/cob_bringup/package.xml
+++ b/cob_bringup/package.xml
@@ -88,7 +88,7 @@
   <exec_depend>theora_image_transport</exec_depend> <!-- needed by the cameras to publish the compressed topics -->
   <exec_depend>topic_tools</exec_depend>
   <exec_depend>twist_mux</exec_depend>
-  <exec_depend>ur_driver</exec_depend>
+  <!--exec_depend>ur_driver</exec_depend-->
   <exec_depend>usb_cam</exec_depend>
   <exec_depend>velocity_controllers</exec_depend>
 

--- a/cob_hardware_config/package.xml
+++ b/cob_hardware_config/package.xml
@@ -33,7 +33,7 @@
   <exec_depend>raw_description</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>rviz</exec_depend>
-  <exec_depend>ur_description</exec_depend>
+  <!--exec_depend>ur_description</exec_depend-->
   <exec_depend>velocity_controllers</exec_depend>
   <exec_depend>xacro</exec_depend>
 

--- a/cob_hardware_config/robots/raw3-1/urdf/raw3-1.urdf.xacro
+++ b/cob_hardware_config/robots/raw3-1/urdf/raw3-1.urdf.xacro
@@ -18,7 +18,7 @@
   <xacro:include filename="$(find raw_description)/urdf/torso/torso_v2.urdf.xacro" />
 
   <!-- ur_arm -->
-  <xacro:include filename="$(find raw_description)/urdf/ur_arm/ur10_arm.urdf.xacro" />
+  <!--xacro:include filename="$(find raw_description)/urdf/ur_arm/ur10_arm.urdf.xacro" /-->
 
   <!-- vacuum gripper -->
   <xacro:include filename="$(find raw_description)/urdf/vacuum_gripper/gripper.urdf.xacro" />
@@ -46,12 +46,12 @@
     <origin xyz="${torso_x} ${torso_y} ${torso_z}" rpy="${torso_roll} ${torso_pitch} ${torso_yaw}" />
   </xacro:raw_torso_v2>
 
-  <xacro:ur10 name="arm" parent="base_link">
+  <!--xacro:ur10 name="arm" parent="base_link">
     <origin xyz="${arm_x} ${arm_y} ${arm_z}" rpy="${arm_roll} ${arm_pitch} ${arm_yaw}" />
   </xacro:ur10>
 
   <xacro:vacuum_gripper name="gripper" parent="arm_ee_link">
     <origin xyz="${gripper_x} ${gripper_y} ${gripper_z}" rpy="${gripper_roll} ${gripper_pitch} ${gripper_yaw}" />
-  </xacro:vacuum_gripper>
+  </xacro:vacuum_gripper-->
 
 </robot>


### PR DESCRIPTION
in https://github.com/ipa320/cob_robots/pull/780 we introduced a new default branch `kinetic_dev` with is supposed to supporte both `kinetic` and `melodic` distros
unfortunately, `universal_robots` is not yet released into `melodic` and also the `ur_driver` is no longer maintained - in favor of `ur_modern_driver`

thus, I commented everything `ur_X`-related in order to achieve the envisaged dual-distro-compatibility

this means that on the real robot hardware (`raw3-1` only), `kinetic_dev` will not work
however, the "old" `indigo_dev` branch is  still `kinetic`-compatible and has the `ur_X` stuff included
thus, when using this branch, `raw3-1` can still be operated as is...as long as `cob_robot` is not switched to `cob_robots/kinetic_dev`

@ipa-jba @ipa-fez @ipa-jcl @ipa-mjp @ipa-mah @ipa-rmb FYI