### PR TITLE
update serial no of sensorring d435 of cob4-7

### DIFF
--- a/cob_bringup/robots/cob4-7.xml
+++ b/cob_bringup/robots/cob4-7.xml
@@ -245,7 +245,7 @@
 			<arg name="name" value="sensorring_cam3d"/>
 			<arg name="sim" value="$(arg sim)"/>
 			<arg name="flip" value="true"/>
-			<arg name="serial_no" value="817412071179"/>
+			<arg name="serial_no" value="817412070851"/>
 		</include>
 	</group>
 


### PR DESCRIPTION
head of `cob4-25` was put on `cob4-7` - so serial number of d435 has changed
ref https://github.com/mojin-robotics/cob4/issues/1230