### PR TITLE
canTransform argument target_frame in tf2 frame_ids cannot start with…

### DIFF
--- a/cob_hardware_config/robots/cob4/config/base_laser_front.yaml
+++ b/cob_hardware_config/robots/cob4/config/base_laser_front.yaml
@@ -4,6 +4,6 @@ scan_duration: 0.025 #no info about that in SICK-docu, but 0.025 is believable a
 scan_cycle_time: 0.040 #SICK-docu says S300 scans every 40ms
 inverted: false
 scan_id: 7
-frame_id: /base_laser_front_link
+frame_id: base_laser_front_link
 publish_frequency: 12
 scan_intervals: [[-1.5, 1.5]] #[rad] these intervals are included to the scan

--- a/cob_hardware_config/robots/cob4/config/base_laser_left.yaml
+++ b/cob_hardware_config/robots/cob4/config/base_laser_left.yaml
@@ -4,6 +4,6 @@ scan_duration: 0.025 #no info about that in SICK-docu, but 0.025 is believable a
 scan_cycle_time: 0.040 #SICK-docu says S300 scans every 40ms
 inverted: false
 scan_id: 7
-frame_id: /base_laser_left_link
+frame_id: base_laser_left_link
 publish_frequency: 12
 scan_intervals: [[-1.5, 1.5]] #[rad] these intervals are included to the scan

--- a/cob_hardware_config/robots/cob4/config/base_laser_right.yaml
+++ b/cob_hardware_config/robots/cob4/config/base_laser_right.yaml
@@ -4,6 +4,6 @@ scan_duration: 0.025 #no info about that in SICK-docu, but 0.025 is believable a
 scan_cycle_time: 0.040 #SICK-docu says S300 scans every 40ms
 inverted: false
 scan_id: 8
-frame_id: /base_laser_right_link
+frame_id: base_laser_right_link
 publish_frequency: 12
 scan_intervals: [[-1.5, 1.5]] #[rad] these intervals are included to the scan

--- a/cob_hardware_config/robots/cob4/config/cob4_base_controller.yaml
+++ b/cob_hardware_config/robots/cob4/config/cob4_base_controller.yaml
@@ -36,8 +36,8 @@ twist_controller:
 odometry_controller:
   type: cob_omni_drive_controller/OdometryController
   publish_rate: 50
-  frame_id: "/odom_combined"
-  child_frame_id: "/base_footprint"
+  frame_id: "odom_combined"
+  child_frame_id: "base_footprint"
   cov_pose: 0.1
   cov_twist: 0.1
   wheels: *wheels

--- a/cob_hardware_config/robots/cob4/config/footprint_observer_params.yaml
+++ b/cob_hardware_config/robots/cob4/config/footprint_observer_params.yaml
@@ -2,7 +2,7 @@
 footprint_source: /local_costmap_node/costmap
 
 #
-robot_base_frame: /base_link
+robot_base_frame: base_link
 # frames to check for footprint adjustment
-frames_to_check: /base_laser_front_link /base_laser_left_link /base_laser_right_link
+frames_to_check: base_laser_front_link base_laser_left_link base_laser_right_link
 epsilon: 0.01

--- a/cob_hardware_config/robots/cob4/config/light_base.yaml
+++ b/cob_hardware_config/robots/cob4/config/light_base.yaml
@@ -4,6 +4,6 @@ baudrate: 38400
 num_leds: 3
 invert_output: false
 pubmarker: true
-marker_frame: /base_link # marker will be publised at [0.5,0,0] with respect to marker_frame
+marker_frame: base_link # marker will be publised at [0.5,0,0] with respect to marker_frame
 startup_color: [0.0, 1.0, 0.5, 0.4] #rgba value
 startup_mode: Static #possible values: None, Static, Breath, BreathColor, Flash, FadeColor

--- a/cob_hardware_config/robots/raw3-1/config/cameras/parameters_left.yaml
+++ b/cob_hardware_config/robots/raw3-1/config/cameras/parameters_left.yaml
@@ -7,7 +7,7 @@ auto_gain:         False
 #gain_auto_target: 40
 gain:              10
 auto_whitebalance: True
-frame_id: /head_color_camera_l_link
+frame_id: head_color_camera_l_link
 stream_bytes_per_second: 55000000 #17500000 full speed in stereo rig: 55000000
 #auto_adjust_stream_bytes_per_second: False
 trigger_mode: streaming

--- a/cob_hardware_config/robots/raw3-1/config/cameras/parameters_right.yaml
+++ b/cob_hardware_config/robots/raw3-1/config/cameras/parameters_right.yaml
@@ -6,7 +6,7 @@ auto_gain:         False
 #gain_auto_target: 40
 gain:              3
 auto_whitebalance: True
-frame_id: /head_color_camera_r_link
+frame_id: head_color_camera_r_link
 stream_bytes_per_second: 124000000
 auto_adjust_stream_bytes_per_second: False
 trigger_mode: streaming

--- a/cob_hardware_config/robots/raw3-1/config/footprint_observer_params.yaml
+++ b/cob_hardware_config/robots/raw3-1/config/footprint_observer_params.yaml
@@ -2,7 +2,7 @@
 footprint_source: /local_costmap_node/costmap
 
 #
-robot_base_frame: /base_link
+robot_base_frame: base_link
 # frames to check for footprint adjustment
 frames_to_check: /arm_forearm_link /arm_wrist_1_link /arm_wrist_2_link /arm_wrist_3_link /arm_ee_link
 epsilon: 0.01

--- a/cob_hardware_config/robots/raw3-1/config/light.yaml
+++ b/cob_hardware_config/robots/raw3-1/config/light.yaml
@@ -4,6 +4,6 @@ baudrate: 38400
 num_leds: 58
 invert_output: false
 pubmarker: false
-marker_frame: /base_link # marker will be publised at [0.5,0,0] with respect to marker_frame
+marker_frame: base_link # marker will be publised at [0.5,0,0] with respect to marker_frame
 startup_color: [0.0, 1.0, 0.0, 1.0] #rgba value
 startup_mode: Static #possible values: None, Static, Breath, BreathColor, Flash...

--- a/cob_hardware_config/robots/raw3-1/config/local_costmap_params.yaml
+++ b/cob_hardware_config/robots/raw3-1/config/local_costmap_params.yaml
@@ -1,6 +1,6 @@
 # global information
-global_frame: /base_link
-robot_base_frame: /base_footprint
+global_frame: base_link
+robot_base_frame: base_footprint
 update_frequency: 5.0
 publish_frequency: 5.0
 

--- a/cob_hardware_config/robots/raw3-3/config/footprint_observer_params.yaml
+++ b/cob_hardware_config/robots/raw3-3/config/footprint_observer_params.yaml
@@ -2,5 +2,5 @@
 footprint_source: /local_costmap_node/costmap
 
 #
-robot_base_frame: /base_link
+robot_base_frame: base_link
 epsilon: 0.01

--- a/cob_hardware_config/robots/raw3-3/config/light.yaml
+++ b/cob_hardware_config/robots/raw3-3/config/light.yaml
@@ -3,6 +3,6 @@ devicestring: /dev/ttyLED
 baudrate: 38400
 invert_output: false
 pubmarker: false
-marker_frame: /base_link # marker will be publised at [0.5,0,0] with respect to marker_frame
+marker_frame: base_link # marker will be publised at [0.5,0,0] with respect to marker_frame
 startup_color: [0.0, 1.0, 0.0, 1.0] #rgba value
 startup_mode: Static #possible values: None, Static, Breath, BreathColor, Flash...

--- a/cob_hardware_config/robots/raw3-3/config/local_costmap_params.yaml
+++ b/cob_hardware_config/robots/raw3-3/config/local_costmap_params.yaml
@@ -1,6 +1,6 @@
 # global information
-global_frame: /base_link
-robot_base_frame: /base_footprint
+global_frame: base_link
+robot_base_frame: base_footprint
 update_frequency: 5.0
 publish_frequency: 5.0
 

--- a/cob_hardware_config/robots/raw3-5/config/footprint_observer_params.yaml
+++ b/cob_hardware_config/robots/raw3-5/config/footprint_observer_params.yaml
@@ -2,9 +2,9 @@
 footprint_source: /local_costmap_node/costmap
 
 #
-robot_base_frame: /base_link
+robot_base_frame: base_link
 # wait until tf from robot_base_frame to farthest_frame is available
-farthest_frame: /base_link
+farthest_frame: base_link
 # frames to check for footprint adjustment
 #frames_to_check: /arm_forearm_link /arm_wrist_1_link /arm_wrist_2_link /arm_wrist_3_link /arm_ee_link
 epsilon: 0.01

--- a/cob_hardware_config/robots/raw3-5/config/local_costmap_params.yaml
+++ b/cob_hardware_config/robots/raw3-5/config/local_costmap_params.yaml
@@ -1,6 +1,6 @@
 # global information
-global_frame: /base_link
-robot_base_frame: /base_footprint
+global_frame: base_link
+robot_base_frame: base_footprint
 update_frequency: 5.0
 publish_frequency: 5.0
 

--- a/cob_hardware_config/robots/raw3/config/raw3_base_controller.yaml
+++ b/cob_hardware_config/robots/raw3/config/raw3_base_controller.yaml
@@ -41,8 +41,8 @@ twist_controller:
 odometry_controller:
   type: cob_omni_drive_controller/OdometryController
   publish_rate: 50
-  frame_id: "/odom_combined"
-  child_frame_id: "/base_footprint"
+  frame_id: "odom_combined"
+  child_frame_id: "base_footprint"
   cov_pose: 0.1
   cov_twist: 0.1
   defaults: # default settings for all wheels, can per overwritten per wheel


### PR DESCRIPTION

canTransform argument target_frame in tf2 frame_ids cannot start with a '/' . The terminal indicates this by a lot of warnings.

- fixed by removing all '/' prefix from frames.
- tested with melodic in simulation